### PR TITLE
fix: move volume_str inside display feature guard

### DIFF
--- a/apps/tuya.ai/your_chat_bot/src/tuya_main.c
+++ b/apps/tuya.ai/your_chat_bot/src/tuya_main.c
@@ -100,8 +100,8 @@ OPERATE_RET audio_dp_obj_proc(dp_obj_recv_t *dpobj)
             uint8_t volume = dp->value.dp_value;
             PR_DEBUG("volume:%d", volume);
             ai_audio_set_volume(volume);
-            char volume_str[20] = {0};
 #if defined(ENABLE_CHAT_DISPLAY) && (ENABLE_CHAT_DISPLAY == 1)
+            char volume_str[20] = {0};
             snprintf(volume_str, sizeof(volume_str), "%s%d", VOLUME, volume);
             app_display_send_msg(TY_DISPLAY_TP_NOTIFICATION, (uint8_t *)volume_str, strlen(volume_str));
 #endif


### PR DESCRIPTION
Declare volume_str only when ENABLE_CHAT_DISPLAY is active to prevent unused variable warning when display is disabled.