### PR TITLE
Add the dimming interface for WAVESHARE_T5AI_TOUCH_AMOLED_1_75

### DIFF
--- a/boards/T5AI/WAVESHARE_T5AI_TOUCH_AMOLED_1_75/board_com_api.c
+++ b/boards/T5AI/WAVESHARE_T5AI_TOUCH_AMOLED_1_75/board_com_api.c
@@ -193,6 +193,13 @@ static OPERATE_RET __board_register_display(void)
     return rt;
 }
 
+
+
+OPERATE_RET board_set_brightness(uint8_t value)
+{
+    return tdd_disp_qspi_co5300_set_bl(value);
+}
+
 /**
  * @brief Registers all the hardware peripherals (audio, button, LED) on the board.
  *

--- a/boards/T5AI/WAVESHARE_T5AI_TOUCH_AMOLED_1_75/board_com_api.h
+++ b/boards/T5AI/WAVESHARE_T5AI_TOUCH_AMOLED_1_75/board_com_api.h
@@ -33,7 +33,7 @@ extern "C" {
  * @return Returns OPERATE_RET_OK on success, or an appropriate error code on failure.
  */
 OPERATE_RET board_register_hardware(void);
-
+OPERATE_RET board_set_brightness(uint8_t value);
 #ifdef __cplusplus
 }
 #endif

--- a/src/peripherals/display/tdd_display/include/tdd_disp_co5300.h
+++ b/src/peripherals/display/tdd_display/include/tdd_disp_co5300.h
@@ -27,6 +27,8 @@ extern "C" {
 
 #define CO5300_CASET                0x2A // Column Address Set
 #define CO5300_RASET                0x2B // Row Address Set
+
+#define CO5300_BL                   0x51 // Set backlight
 /***********************************************************
 ***********************typedef define***********************
 ***********************************************************/
@@ -36,7 +38,7 @@ extern "C" {
 ********************function declaration********************
 ***********************************************************/
 OPERATE_RET tdd_disp_qspi_co5300_register(char *name, DISP_QSPI_DEVICE_CFG_T *dev_cfg);
-
+OPERATE_RET tdd_disp_qspi_co5300_set_bl(uint8_t value);
 
 #ifdef __cplusplus
 }

--- a/src/peripherals/display/tdd_display/src/qspi/tdd_disp_qspi_co5300.c
+++ b/src/peripherals/display/tdd_display/src/qspi/tdd_disp_qspi_co5300.c
@@ -99,6 +99,13 @@ void __tdd_disp_qspi_co5300_set_window(DISP_QSPI_BASE_CFG_T *p_cfg, uint16_t x_s
     }
 }
 
+OPERATE_RET tdd_disp_qspi_co5300_set_bl(uint8_t value)
+{
+    if (value == 0) {
+        value = 5;
+    }
+    return tdd_disp_qspi_send_cmd((DISP_QSPI_BASE_CFG_T*)&sg_disp_qspi_cfg, CO5300_BL, &value, 1);
+}
 
 OPERATE_RET tdd_disp_qspi_co5300_register(char *name, DISP_QSPI_DEVICE_CFG_T *dev_cfg)
 {


### PR DESCRIPTION
### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]
Newly added backlight adjustment API, facilitating users to adjust the backlight brightness of WAVESHARE_T5AI_TOUCH_AMOLED_1_75.

### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
