### PR TITLE
fix: improve cloud service dp_schema_find null checks

### DIFF
--- a/src/tuya_cloud_service/schema/dp_schema.c
+++ b/src/tuya_cloud_service/schema/dp_schema.c
@@ -144,11 +144,15 @@ dp_node_t *dp_node_find(dp_schema_t *schema, int id)
 dp_schema_t *dp_schema_find(const char *devid)
 {
     int i = 0;
-
-    PR_TRACE("try to find schema devid %s", devid);
     dp_schema_mgr_t *dsmgr = &s_dsmgr;
+
+    if (NULL == devid) {
+        PR_TRACE("find schema called with NULL devid");
+        return NULL;
+    }
+    PR_TRACE("try to find schema devid %s", devid);
     for (i = 0; i < DP_SCHEMA_NUM_MAX; i++) {
-        if (NULL == dsmgr->schema_list[i]) {
+        if (NULL == dsmgr->schema_list[i] || NULL == dsmgr->schema_list[i]->devid) {
             continue;
         }
         if (0 == strcmp(devid, dsmgr->schema_list[i]->devid)) {


### PR DESCRIPTION
### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]
Added NULL checks in "src/tuya_cloud_service/schema/dp_schema.c" to prevent the issue I previously encountered in my own application.

### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
