### PR TITLE
feat(mimiclaw): add MiniMax as first-class LLM provider

### DIFF
--- a/apps/mimiclaw/README.md
+++ b/apps/mimiclaw/README.md
@@ -10,7 +10,7 @@ TuyaOpen provides drivers, display, peripherals, and connectivity layers, greatl
 ### What you get
 
 - **Local‑first AI assistant** running on Tuya T5AI or Linux
-- **Multiple LLM providers**: DeepSeek, Qwen, Claude, GPT, and other OpenAI/Anthropic‑compatible endpoints
+- **Multiple LLM providers**: DeepSeek, Qwen, Claude, GPT, MiniMax, and other OpenAI/Anthropic‑compatible endpoints
 - **Multiple chat channels**: Telegram / Discord / Feishu (configurable)
 - **Persistent memory** stored as plain text on flash
 - **Cron‑style scheduler & heartbeat loop** so the AI can wake itself up and act
@@ -31,7 +31,7 @@ This TuyaOpen port is **based on** the upstream MimiClaw project and keeps the c
   - Adds first‑class **Feishu** support, in addition to **Telegram** and **Discord**
   - Unified CLI to switch the active channel at runtime
 - **Model configuration**
-  - Supports both **OpenAI** and **Anthropic** providers, plus **compatible base URLs**
+  - Supports **OpenAI**, **Anthropic**, and **MiniMax** providers, plus **compatible base URLs**
   - CLI and config‑file driven model/provider selection
 - **TuyaOpen integration**
   - Uses TuyaOpen’s rich **drivers, sensors, and displays**, enabling the AI to read sensors, drive GPIOs, and control more complex hardware devices
@@ -58,19 +58,21 @@ This prints the list of supported CLI commands for this port.
 
 ### 2. Configure model provider & API
 
-You can choose `openai` or `anthropic` as the provider. The project also supports **OpenAI/Anthropic‑compatible base URLs**.
+You can choose `openai`, `anthropic`, or `minimax` as the provider. The project also supports **OpenAI/Anthropic‑compatible base URLs**.
 
 Typical steps:
 
-1. Select provider (for example, OpenAI or Anthropic compatible):
+1. Select provider (for example, OpenAI, Anthropic, or MiniMax):
    - `set_model_provider openai`
    - or `set_model_provider anthropic`
+   - or `set_model_provider minimax`
 2. Set API key:
    - `set_api_key sk-xxxx...`
 3. (Optional) Use a compatible API base URL:
    - `set_api_url https://your-compatible-endpoint.example.com`
 4. Set model name:
    - `set_model gpt-4o` (or any supported model by your provider)
+   - For MiniMax: `set_model MiniMax-M2.7` or `set_model MiniMax-M2.5-highspeed` (204K context)
 
 If you provide a compatible URL, make sure both **API_KEY** and **API_URL** are set, otherwise calls will fail.
 

--- a/apps/mimiclaw/README_zh.md
+++ b/apps/mimiclaw/README_zh.md
@@ -4,7 +4,7 @@
 插上电、连上 Wi‑Fi，这块几十块钱的 T5AI 板子就会变成一个可以 7×24 小时运行的超级 AI 管家。
 
 你可以通过 **飞书 / Telegram / Discord** 直接和它对话，把任务丢给它处理；  
-它支持 **DeepSeek、Claude、GPT 等主流大模型**，可以在不同模型和兼容接口之间灵活切换；  
+它支持 **DeepSeek、Claude、GPT、MiniMax 等主流大模型**，可以在不同模型和兼容接口之间灵活切换；  
 它有本地记忆，所有对话和偏好都以纯文本文件保存在芯片里，重启不丢失，用得越久越懂你。
 
 它还内置了 **定时任务调度器**，可以让 AI 自己安排每日提醒、定时汇总；  
@@ -30,7 +30,7 @@
   - 在原本 Telegram 的基础上，增加了 **飞书** 与 **Discord** 支持
   - 通过统一的 CLI 命令切换当前使用的社交通道
 - **大模型配置方式**
-  - 支持 **OpenAI** 与 **Anthropic**，同时支持 **兼容 OpenAI/Anthropic 协议的自建 / 第三方 URL**
+  - 支持 **OpenAI**、**Anthropic** 与 **MiniMax**，同时支持 **兼容 OpenAI/Anthropic 协议的自建 / 第三方 URL**
   - 可通过命令行与 `mimi_secrets.h` 双层配置模型与 API
 - **与 TuyaOpen 深度集成**
   - 利用 TuyaOpen 的 **驱动、传感器与显示能力**，让 AI 能够读取环境数据、控制 GPIO 以及更多硬件外设
@@ -55,28 +55,30 @@ help
 
 即可获取到当前固件支持的命令行工具列表和帮助信息。
 
-### 2. 配置大模型（OpenAI / Anthropic / 兼容 URL）
+### 2. 配置大模型（OpenAI / Anthropic / MiniMax / 兼容 URL）
 
-你可以选择 `openai` 或 `anthropic` 作为模型提供方，也可以使用 **OpenAI / Anthropic 协议兼容的自建或第三方接口**。
+你可以选择 `openai`、`anthropic` 或 `minimax` 作为模型提供方，也可以使用 **OpenAI / Anthropic 协议兼容的自建或第三方接口**。
 
 典型配置流程：
 
 1. 选择模型提供方：
    - `set_model_provider openai`
    - 或 `set_model_provider anthropic`
+   - 或 `set_model_provider minimax`
 2. 设置 API Key：
    - `set_api_key sk-xxxx...`
 3. （可选）设置兼容的 API Base URL：
    - `set_api_url https://your-compatible-endpoint.example.com`
 4. 设置模型名称：
    - `set_model gpt-4o`（或你所使用提供方支持的任意模型）
+   - MiniMax 可选：`set_model MiniMax-M2.7` 或 `set_model MiniMax-M2.5-highspeed`（204K 上下文窗口）
 
 如果你选择“兼容 URL”模式，**必须**同时设置 `API_KEY` 和 `API_URL`，缺一不可，否则接口调用会失败。
 
 对应你原始提到的迁移说明，可以理解为：
 
 1. **115200 打开烧录口，输入 `help`，可以获取到命令行工具**
-2. **配置大模型，选择 `openai` 或者 `anthropic`，然后输入 `API_KEY` 和 模型；如果使用兼容 URL，需要额外输入 `API_URL`**
+2. **配置大模型，选择 `openai`、`anthropic` 或 `minimax`，然后输入 `API_KEY` 和 模型；如果使用兼容 URL，需要额外输入 `API_URL`**
 
 ### 3. 连接路由器（Wi‑Fi 配网）
 
@@ -141,7 +143,7 @@ cp apps/tuya_mimiclaw/mimi_secrets.h.example apps/tuya_mimiclaw/mimi_secrets.h
 
 - Wi‑Fi 名称与密码
 - 大模型 API Key、模型名称
-- 模型提供方（OpenAI / Anthropic / 兼容 URL）
+- 模型提供方（OpenAI / Anthropic / MiniMax / 兼容 URL）
 - 对话通道及必要的 Token / AppID 等
 
 保存后重新编译并烧录固件即可。

--- a/apps/mimiclaw/cli/serial_cli.c
+++ b/apps/mimiclaw/cli/serial_cli.c
@@ -182,7 +182,7 @@ static const cli_help_item_t s_cli_help_items[] = {
         .name      = "set_model_provider",
         .usage     = "<provider>",
         .summary_1 = "Set LLM model provider (default: " MIMI_LLM_PROVIDER_DEFAULT ")",
-        .arg_1     = "    <provider>  Model provider (anthropic|openai)",
+        .arg_1     = "    <provider>  Model provider (anthropic|openai|minimax)",
         .verbose   = 0,
     },
     {
@@ -485,6 +485,9 @@ static const char *llm_default_api_url_for_provider(void)
 
     if (strcmp(provider, "openai") == 0) {
         return MIMI_OPENAI_API_URL;
+    }
+    if (strcmp(provider, "minimax") == 0) {
+        return MIMI_MINIMAX_API_URL;
     }
     return MIMI_LLM_API_URL;
 }

--- a/apps/mimiclaw/llm/llm_proxy.c
+++ b/apps/mimiclaw/llm/llm_proxy.c
@@ -18,6 +18,8 @@ static uint8_t *s_openai_cacert        = NULL;
 static size_t   s_openai_cacert_len    = 0;
 static uint8_t *s_anthropic_cacert     = NULL;
 static size_t   s_anthropic_cacert_len = 0;
+static uint8_t *s_minimax_cacert       = NULL;
+static size_t   s_minimax_cacert_len   = 0;
 
 typedef struct {
     char host[96];
@@ -26,6 +28,7 @@ typedef struct {
 
 static llm_endpoint_t s_openai_endpoint    = {0};
 static llm_endpoint_t s_anthropic_endpoint = {0};
+static llm_endpoint_t s_minimax_endpoint   = {0};
 
 #define LLM_LOG_PREVIEW_LEN 1024
 
@@ -65,6 +68,16 @@ static bool provider_is_openai(void)
     return strcmp(s_provider, "openai") == 0;
 }
 
+static bool provider_is_minimax(void)
+{
+    return strcmp(s_provider, "minimax") == 0;
+}
+
+static bool provider_uses_openai_format(void)
+{
+    return provider_is_openai() || provider_is_minimax();
+}
+
 static void free_cached_cert(uint8_t **cert, size_t *cert_len)
 {
     if (cert && *cert) {
@@ -80,13 +93,21 @@ static void clear_endpoint_cache(void)
 {
     memset(&s_openai_endpoint, 0, sizeof(s_openai_endpoint));
     memset(&s_anthropic_endpoint, 0, sizeof(s_anthropic_endpoint));
+    memset(&s_minimax_endpoint, 0, sizeof(s_minimax_endpoint));
     free_cached_cert(&s_openai_cacert, &s_openai_cacert_len);
     free_cached_cert(&s_anthropic_cacert, &s_anthropic_cacert_len);
+    free_cached_cert(&s_minimax_cacert, &s_minimax_cacert_len);
 }
 
 static const char *llm_default_endpoint_url(void)
 {
-    return provider_is_openai() ? MIMI_OPENAI_API_URL : MIMI_LLM_API_URL;
+    if (provider_is_openai()) {
+        return MIMI_OPENAI_API_URL;
+    }
+    if (provider_is_minimax()) {
+        return MIMI_MINIMAX_API_URL;
+    }
+    return MIMI_LLM_API_URL;
 }
 
 static const char *llm_active_endpoint_url(void)
@@ -131,7 +152,14 @@ static void parse_endpoint_url(const char *url, llm_endpoint_t *endpoint)
 
 static llm_endpoint_t *llm_current_endpoint(void)
 {
-    llm_endpoint_t *endpoint = provider_is_openai() ? &s_openai_endpoint : &s_anthropic_endpoint;
+    llm_endpoint_t *endpoint;
+    if (provider_is_openai()) {
+        endpoint = &s_openai_endpoint;
+    } else if (provider_is_minimax()) {
+        endpoint = &s_minimax_endpoint;
+    } else {
+        endpoint = &s_anthropic_endpoint;
+    }
     parse_endpoint_url(llm_active_endpoint_url(), endpoint);
     return endpoint;
 }
@@ -159,6 +187,9 @@ static void get_provider_cert(uint8_t **cert, size_t **cert_len)
     if (provider_is_openai()) {
         *cert     = s_openai_cacert;
         *cert_len = &s_openai_cacert_len;
+    } else if (provider_is_minimax()) {
+        *cert     = s_minimax_cacert;
+        *cert_len = &s_minimax_cacert_len;
     } else {
         *cert     = s_anthropic_cacert;
         *cert_len = &s_anthropic_cacert_len;
@@ -197,6 +228,8 @@ static OPERATE_RET ensure_provider_cert(void)
 
     if (provider_is_openai()) {
         s_openai_cacert = cert;
+    } else if (provider_is_minimax()) {
+        s_minimax_cacert = cert;
     } else {
         s_anthropic_cacert = cert;
     }
@@ -515,7 +548,7 @@ static OPERATE_RET llm_http_call(const char *post_data, char *resp_buf, size_t r
         .value = "application/json",
     };
 
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         snprintf(auth, sizeof(auth), "Bearer %s", s_api_key);
         headers[header_count++] = (http_client_header_t){
             .key   = "Authorization",
@@ -676,7 +709,7 @@ OPERATE_RET llm_chat(const char *system_prompt, const char *messages_json, char 
         return OPRT_MALLOC_FAILED;
     }
     cJSON_AddStringToObject(body, "model", s_model);
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         cJSON_AddNumberToObject(body, "max_completion_tokens", MIMI_LLM_MAX_TOKENS);
     } else {
         cJSON_AddNumberToObject(body, "max_tokens", MIMI_LLM_MAX_TOKENS);
@@ -699,7 +732,7 @@ OPERATE_RET llm_chat(const char *system_prompt, const char *messages_json, char 
         cJSON_AddItemToArray(parsed_messages, msg);
     }
 
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         cJSON *openai_msgs = convert_messages_openai(system_prompt, parsed_messages);
         if (!openai_msgs) {
             cJSON_Delete(parsed_messages);
@@ -752,7 +785,7 @@ OPERATE_RET llm_chat(const char *system_prompt, const char *messages_json, char 
         return OPRT_CR_CJSON_ERR;
     }
 
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         extract_text_openai(root, response_buf, buf_size);
     } else {
         extract_text_anthropic(root, response_buf, buf_size);
@@ -810,13 +843,13 @@ OPERATE_RET llm_chat_tools_ex(const char *system_prompt, cJSON *messages, const 
     }
 
     cJSON_AddStringToObject(body, "model", s_model);
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         cJSON_AddNumberToObject(body, "max_completion_tokens", MIMI_LLM_MAX_TOKENS);
     } else {
         cJSON_AddNumberToObject(body, "max_tokens", MIMI_LLM_MAX_TOKENS);
     }
 
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         cJSON *openai_msgs = convert_messages_openai(system_prompt, messages);
         if (!openai_msgs) {
             cJSON_Delete(body);
@@ -883,7 +916,7 @@ OPERATE_RET llm_chat_tools_ex(const char *system_prompt, cJSON *messages, const 
         return OPRT_CR_CJSON_ERR;
     }
 
-    if (provider_is_openai()) {
+    if (provider_uses_openai_format()) {
         cJSON *choices = cJSON_GetObjectItem(root, "choices");
         cJSON *choice0 = cJSON_IsArray(choices) ? cJSON_GetArrayItem(choices, 0) : NULL;
         if (choice0) {

--- a/apps/mimiclaw/mimi_config.h
+++ b/apps/mimiclaw/mimi_config.h
@@ -129,6 +129,9 @@
 #ifndef MIMI_OPENAI_API_URL
 #define MIMI_OPENAI_API_URL "https://api.openai.com/v1/chat/completions"
 #endif
+#ifndef MIMI_MINIMAX_API_URL
+#define MIMI_MINIMAX_API_URL "https://api.minimax.io/v1/chat/completions"
+#endif
 #define MIMI_LLM_API_VERSION         "2023-06-01"
 #define MIMI_LLM_STREAM_BUF_SIZE     (32 * 1024)
 #define MIMI_LLM_LOG_VERBOSE_PAYLOAD 0

--- a/apps/mimiclaw/mimi_secrets.h.example
+++ b/apps/mimiclaw/mimi_secrets.h.example
@@ -29,15 +29,17 @@
 /* Channel Mode: telegram | discord | feishu */
 #define MIMI_SECRET_CHANNEL_MODE    "telegram"
 
-/* Anthropic API */
+/* LLM API: provider = anthropic | openai | minimax */
 #define MIMI_SECRET_API_KEY         ""
 #define MIMI_SECRET_MODEL           ""
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"
 
-/* Anthropic URL or OpenAI URL */
+/* Provider-specific URLs (auto-selected by provider, override if needed) */
 #define MIMI_LLM_API_URL             "https://api.anthropic.com/v1/messages"
 // or
 #define MIMI_OPENAI_API_URL          "https://api.openai.com/v1/chat/completions"
+// or
+#define MIMI_MINIMAX_API_URL         "https://api.minimax.io/v1/chat/completions"
 
 /* HTTP Proxy (leave empty or set both) */
 #define MIMI_SECRET_PROXY_HOST      ""

--- a/apps/mimiclaw/tests/test_minimax_provider.py
+++ b/apps/mimiclaw/tests/test_minimax_provider.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Unit and integration tests for MiniMax LLM provider support in MimiClaw.
+
+Since MimiClaw is an embedded C firmware, these tests validate:
+1. Source-level correctness of the provider routing changes
+2. MiniMax API compatibility via direct HTTP calls (integration)
+
+Usage:
+    python3 -m pytest tests/test_minimax_provider.py -v
+    # or: python3 tests/test_minimax_provider.py
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+# Paths relative to the mimiclaw app root
+MIMICLAW_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LLM_PROXY_C = os.path.join(MIMICLAW_ROOT, "llm", "llm_proxy.c")
+LLM_PROXY_H = os.path.join(MIMICLAW_ROOT, "llm", "llm_proxy.h")
+MIMI_CONFIG_H = os.path.join(MIMICLAW_ROOT, "mimi_config.h")
+SERIAL_CLI_C = os.path.join(MIMICLAW_ROOT, "cli", "serial_cli.c")
+MIMI_SECRETS_EXAMPLE = os.path.join(MIMICLAW_ROOT, "mimi_secrets.h.example")
+README_MD = os.path.join(MIMICLAW_ROOT, "README.md")
+README_ZH_MD = os.path.join(MIMICLAW_ROOT, "README_zh.md")
+
+
+def read_file(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: validate C source code structure
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxProviderConfig(unittest.TestCase):
+    """Verify mimi_config.h has the MiniMax API URL defined."""
+
+    def setUp(self):
+        self.config = read_file(MIMI_CONFIG_H)
+
+    def test_minimax_api_url_defined(self):
+        self.assertIn("MIMI_MINIMAX_API_URL", self.config)
+
+    def test_minimax_api_url_value(self):
+        match = re.search(
+            r'#define\s+MIMI_MINIMAX_API_URL\s+"([^"]+)"', self.config
+        )
+        self.assertIsNotNone(match, "MIMI_MINIMAX_API_URL should have a default value")
+        self.assertEqual(
+            match.group(1), "https://api.minimax.io/v1/chat/completions"
+        )
+
+    def test_minimax_url_guarded_by_ifndef(self):
+        self.assertIn("#ifndef MIMI_MINIMAX_API_URL", self.config)
+
+    def test_openai_and_anthropic_urls_preserved(self):
+        self.assertIn("MIMI_OPENAI_API_URL", self.config)
+        self.assertIn("MIMI_LLM_API_URL", self.config)
+        self.assertIn("api.openai.com", self.config)
+        self.assertIn("api.anthropic.com", self.config)
+
+
+class TestMiniMaxProviderRouting(unittest.TestCase):
+    """Verify llm_proxy.c has correct MiniMax provider routing."""
+
+    def setUp(self):
+        self.proxy = read_file(LLM_PROXY_C)
+
+    def test_provider_is_minimax_function_exists(self):
+        self.assertIn("provider_is_minimax", self.proxy)
+
+    def test_provider_uses_openai_format_function_exists(self):
+        self.assertIn("provider_uses_openai_format", self.proxy)
+
+    def test_provider_uses_openai_format_includes_minimax(self):
+        match = re.search(
+            r"static bool provider_uses_openai_format\(void\)\s*\{([^}]+)\}",
+            self.proxy,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("provider_is_openai()", body)
+        self.assertIn("provider_is_minimax()", body)
+
+    def test_minimax_endpoint_cache_exists(self):
+        self.assertIn("s_minimax_endpoint", self.proxy)
+        self.assertIn("s_minimax_cacert", self.proxy)
+        self.assertIn("s_minimax_cacert_len", self.proxy)
+
+    def test_clear_endpoint_cache_handles_minimax(self):
+        match = re.search(
+            r"static void clear_endpoint_cache\(void\)\s*\{([^}]+)\}",
+            self.proxy,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("s_minimax_endpoint", body)
+        self.assertIn("s_minimax_cacert", body)
+
+    def test_llm_default_endpoint_url_handles_minimax(self):
+        match = re.search(
+            r"static const char \*llm_default_endpoint_url\(void\)\s*\{([\s\S]*?)\n\}",
+            self.proxy,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("provider_is_minimax()", body)
+        self.assertIn("MIMI_MINIMAX_API_URL", body)
+
+    def test_auth_header_uses_openai_format(self):
+        """MiniMax should use Bearer auth (same as OpenAI)."""
+        self.assertIn("provider_uses_openai_format()", self.proxy)
+        # The old code had provider_is_openai() for auth; now it should be
+        # provider_uses_openai_format() so MiniMax gets Bearer auth too
+        auth_section = self.proxy[
+            self.proxy.find("llm_http_call") : self.proxy.find("http_client_request")
+        ]
+        self.assertIn("provider_uses_openai_format()", auth_section)
+
+    def test_message_format_uses_openai_format(self):
+        """MiniMax should use OpenAI message format."""
+        chat_func = self.proxy[
+            self.proxy.find("OPERATE_RET llm_chat(") : self.proxy.find(
+                "void llm_response_free"
+            )
+        ]
+        self.assertIn("provider_uses_openai_format()", chat_func)
+        self.assertNotIn(
+            "provider_is_openai()", chat_func,
+            "llm_chat should use provider_uses_openai_format(), not provider_is_openai()"
+        )
+
+    def test_response_parsing_uses_openai_format(self):
+        """MiniMax should use OpenAI response parsing."""
+        tools_func = self.proxy[
+            self.proxy.find("OPERATE_RET llm_chat_tools_ex(") :
+        ]
+        self.assertIn("provider_uses_openai_format()", tools_func)
+
+    def test_get_provider_cert_handles_minimax(self):
+        match = re.search(
+            r"static void get_provider_cert\([^)]+\)\s*\{([\s\S]*?)\n\}",
+            self.proxy,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("provider_is_minimax()", body)
+        self.assertIn("s_minimax_cacert", body)
+
+    def test_ensure_provider_cert_handles_minimax(self):
+        match = re.search(
+            r"static OPERATE_RET ensure_provider_cert\(void\)\s*\{([\s\S]*?)\n\}",
+            self.proxy,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("provider_is_minimax()", body)
+        self.assertIn("s_minimax_cacert", body)
+
+    def test_provider_is_openai_still_exists(self):
+        """Original provider_is_openai should still exist for endpoint routing."""
+        self.assertIn("provider_is_openai(void)", self.proxy)
+
+    def test_no_raw_provider_is_openai_in_message_format(self):
+        """provider_is_openai() should NOT be used for message/auth format decisions."""
+        # Extract the sections after the helper function definitions
+        after_helpers = self.proxy[self.proxy.find("static cJSON *convert_tools_openai"):]
+        # Count occurrences: provider_is_openai() should only appear in
+        # endpoint routing and cert caching, not in format decisions
+        openai_count = after_helpers.count("provider_is_openai()")
+        format_count = after_helpers.count("provider_uses_openai_format()")
+        # provider_uses_openai_format should be used in all format decisions
+        self.assertGreater(format_count, 0)
+
+
+class TestCLIMiniMaxSupport(unittest.TestCase):
+    """Verify serial_cli.c recognizes MiniMax as a provider."""
+
+    def setUp(self):
+        self.cli = read_file(SERIAL_CLI_C)
+
+    def test_cli_help_mentions_minimax(self):
+        self.assertIn("minimax", self.cli.lower())
+
+    def test_provider_help_includes_minimax(self):
+        self.assertIn("anthropic|openai|minimax", self.cli)
+
+    def test_llm_default_api_url_handles_minimax(self):
+        match = re.search(
+            r"static const char \*llm_default_api_url_for_provider\(void\)\s*\{([\s\S]*?)\n\}",
+            self.cli,
+        )
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn('"minimax"', body)
+        self.assertIn("MIMI_MINIMAX_API_URL", body)
+
+
+class TestSecretsExample(unittest.TestCase):
+    """Verify mimi_secrets.h.example documents MiniMax."""
+
+    def setUp(self):
+        self.secrets = read_file(MIMI_SECRETS_EXAMPLE)
+
+    def test_minimax_mentioned_in_provider_comment(self):
+        self.assertIn("minimax", self.secrets.lower())
+
+    def test_minimax_url_in_example(self):
+        self.assertIn("MIMI_MINIMAX_API_URL", self.secrets)
+        self.assertIn("api.minimax.io", self.secrets)
+
+
+class TestREADMEDocumentation(unittest.TestCase):
+    """Verify README files document MiniMax provider."""
+
+    def test_readme_en_mentions_minimax(self):
+        readme = read_file(README_MD)
+        self.assertIn("MiniMax", readme)
+        self.assertIn("set_model_provider minimax", readme)
+        self.assertIn("MiniMax-M2.7", readme)
+
+    def test_readme_zh_mentions_minimax(self):
+        readme_zh = read_file(README_ZH_MD)
+        self.assertIn("MiniMax", readme_zh)
+        self.assertIn("set_model_provider minimax", readme_zh)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: verify MiniMax API compatibility
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxAPIIntegration(unittest.TestCase):
+    """Integration tests that call the real MiniMax API."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Load API key from env or .env.local
+        cls.api_key = os.environ.get("MINIMAX_API_KEY", "")
+        if not cls.api_key:
+            env_path = os.path.join(
+                os.path.dirname(MIMICLAW_ROOT), "..", "..", "..", ".env.local"
+            )
+            env_path = os.path.normpath(env_path)
+            if os.path.exists(env_path):
+                with open(env_path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if line.startswith("MINIMAX_API_KEY="):
+                            cls.api_key = line.split("=", 1)[1].strip().strip('"').strip("'")
+                            break
+
+    def _skip_without_key(self):
+        if not self.api_key:
+            self.skipTest("MINIMAX_API_KEY not set")
+
+    def _call_minimax(self, payload):
+        """Call MiniMax API using the same format as llm_proxy.c OpenAI path."""
+        import urllib.request
+        import urllib.error
+
+        url = "https://api.minimax.io/v1/chat/completions"
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8")), resp.status
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body) if body else {}, e.code
+
+    def test_basic_chat_completion(self):
+        """Verify MiniMax accepts OpenAI-format chat/completions request."""
+        self._skip_without_key()
+        payload = {
+            "model": "MiniMax-M2.7",
+            "max_completion_tokens": 64,
+            "messages": [
+                {"role": "system", "content": "Reply in one word."},
+                {"role": "user", "content": "What is 2+2?"},
+            ],
+        }
+        resp, status = self._call_minimax(payload)
+        self.assertEqual(status, 200, f"API returned {status}: {resp}")
+        # Validate OpenAI-format response structure
+        self.assertIn("choices", resp)
+        self.assertIsInstance(resp["choices"], list)
+        self.assertGreater(len(resp["choices"]), 0)
+        choice = resp["choices"][0]
+        self.assertIn("message", choice)
+        self.assertIn("content", choice["message"])
+        self.assertIn("finish_reason", choice)
+
+    def test_tool_calling(self):
+        """Verify MiniMax supports OpenAI-format tool calling."""
+        self._skip_without_key()
+        payload = {
+            "model": "MiniMax-M2.7",
+            "max_completion_tokens": 128,
+            "messages": [
+                {"role": "user", "content": "What time is it in Tokyo?"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_time",
+                        "description": "Get current time in a timezone",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "timezone": {
+                                    "type": "string",
+                                    "description": "IANA timezone name",
+                                }
+                            },
+                            "required": ["timezone"],
+                        },
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+        }
+        resp, status = self._call_minimax(payload)
+        self.assertEqual(status, 200, f"API returned {status}: {resp}")
+        self.assertIn("choices", resp)
+        # Either tool_calls or regular content is acceptable
+        choice = resp["choices"][0]
+        self.assertIn("message", choice)
+
+    def test_bearer_auth_format(self):
+        """Verify MiniMax accepts Bearer token auth (same as OpenAI)."""
+        self._skip_without_key()
+        payload = {
+            "model": "MiniMax-M2.7",
+            "max_completion_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        resp, status = self._call_minimax(payload)
+        self.assertEqual(status, 200, f"Bearer auth should work: {resp}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add **MiniMax AI** as a third LLM provider in the MimiClaw embedded AI agent, alongside OpenAI and Anthropic.

MiniMax offers an OpenAI-compatible API, so this change introduces a `provider_uses_openai_format()` helper to share the existing OpenAI message format, Bearer auth, and response parsing path, while routing requests to MiniMax's own endpoint (`api.minimax.io/v1/chat/completions`).

### Changes

- **llm_proxy.c**: Add `provider_is_minimax()`, `provider_uses_openai_format()`, separate endpoint/cert cache for MiniMax, three-way provider routing in endpoint URL, cert management, and HTTP auth
- **mimi_config.h**: Add `MIMI_MINIMAX_API_URL` with `#ifndef` guard
- **serial_cli.c**: Update CLI help text (`anthropic|openai|minimax`) and default URL routing
- **mimi_secrets.h.example**: Document MiniMax as a provider option
- **README.md / README_zh.md**: Add MiniMax to provider documentation with model names
- **tests/test_minimax_provider.py**: 24 unit tests (source-level validation) + 3 integration tests (real API calls)

### Usage



Available models:  (latest, 1M context),  (204K context)

### Design

MiniMax uses the same OpenAI-compatible format for:
- Message structure (system/user/assistant roles)
- Bearer token authentication
- Response format (choices[].message.content)
- Tool calling (function type)

This means all existing OpenAI format code paths are reused via `provider_uses_openai_format()`, keeping the diff minimal. Only endpoint routing and TLS cert caching needed three-way provider dispatch.

### Test Plan

- [x] 24 unit tests validate C source-level correctness (provider routing, config, CLI, docs)
- [x] 3 integration tests verify real MiniMax API compatibility (chat, tool calling, auth)
- [x] All 27 tests passing
