### PR TITLE
fix: update windows-curses for windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PyYAML==6.0.2
 requests==2.32.3
 smmap==5.0.2
 urllib3==2.2.3
-windows-curses==2.4.1; sys_platform == "win32"
+windows-curses>=2.4.2; sys_platform == "win32"
 cffi>=1.16.0
 click-option-group>=0.5.6
 cryptography>=42.0.8


### PR DESCRIPTION
## Summary
Add a Windows-only dependency for `windows-curses` so the project can run on Windows without import/runtime issues.

## Why
I verified that `windows-curses==2.4.1` does not work reliably in the current Windows environment and the code path still fails to run cleanly.  
Upgrading to `windows-curses>=2.4.2` resolves the issue and allows the build/runtime flow to proceed.

## Change
- Update `requirements.txt`
- Add `windows-curses>=2.4.2; platform_system == "Windows"`

## Notes
The version is constrained to Windows only, so Linux/macOS environments are unaffected.