### PR TITLE
fix(dp): guard null client and default devid in dp obj report

### DIFF
--- a/src/tuya_cloud_service/schema/tuya_iot_dp.c
+++ b/src/tuya_cloud_service/schema/tuya_iot_dp.c
@@ -205,7 +205,7 @@ int tuya_iot_dp_parse(tuya_iot_client_t *client, dp_cmd_type_t cmd_tp, cJSON *cm
  * service.
  *
  * @param client The Tuya IoT client instance.
- * @param devid The device ID.
+ * @param devid The device ID. Uses client->activate.devid when NULL or empty.
  * @param dps An array of device object data.
  * @param dpscnt The number of device object data elements in the array.
  * @param flags Additional flags for the report.
@@ -217,12 +217,19 @@ int tuya_iot_dp_obj_report(tuya_iot_client_t *client, const char *devid, dp_obj_
 {
     int ret = OPRT_OK;
 
+    if (NULL == client) {
+        return OPRT_INVALID_PARM;
+    }
     if (!client->is_activated) {
         PR_DEBUG("client no active");
         return OPRT_COM_ERROR;
     }
     if (NULL == dps || 0 == dpscnt) {
         return OPRT_INVALID_PARM;
+    }
+
+    if (NULL == devid || '\0' == devid[0]) {
+        devid = client->activate.devid;
     }
 
     dp_schema_t *schema = dp_schema_find(devid);


### PR DESCRIPTION
Return OPRT_INVALID_PARM when client is NULL, and fall back to client->activate.devid when devid is NULL or empty.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
