### PR TITLE
feat(config): add -l/--list option to config choice command

### DIFF
--- a/tools/cli_command/cli_config.py
+++ b/tools/cli_command/cli_config.py
@@ -6,6 +6,8 @@
 #   tos.py config choice -d                     # interactive selection from board default configs
 #   tos.py config choice -c my_board.config     # non-interactive, specify config by name
 #   tos.py config choice -d -c my_board.config  # non-interactive, from board default configs
+#   tos.py config choice -l                     # list all available app configs
+#   tos.py config choice -d -l                  # list all board default configs
 #   tos.py config menu                          # open menuconfig UI
 #   tos.py config save                          # save current config to app configs
 
@@ -97,14 +99,16 @@ def get_board_config_dir(board_path):
 @click.option('-c', '--config',
               default=None, metavar='NAME',
               help="Specify config file name directly (e.g. my_board.config), skipping interactive selection.")
-def config_choice_exec(default, config):
+@click.option('-l', '--list', 'list_configs',
+              is_flag=True, default=False,
+              help="List all available config files.")
+def config_choice_exec(default, config, list_configs):
     '''
     Choice config file
     from app config or board default config
     '''
     logger = get_logger()
     params = get_global_params()
-    full_clean_project()
 
     # get config files
     app_configs_path = params["app_configs_path"]
@@ -118,6 +122,14 @@ def config_choice_exec(default, config):
         config_list = get_files_from_path(".config", config_dir, 0)
 
     config_list.sort()
+
+    if list_configs:
+        show_list = [os.path.basename(f) for f in config_list]
+        for name in show_list:
+            print(name)
+        sys.exit(0)
+
+    full_clean_project()
 
     if config is not None:
         # non-interactive: match by filename


### PR DESCRIPTION
Allows listing all available config files without entering interactive mode or triggering a full project clean.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
