### PR TITLE
fix(iotdns): parse host and port from register center urls

### DIFF
--- a/src/tuya_cloud_service/cloud/iotdns.c
+++ b/src/tuya_cloud_service/cloud/iotdns.c
@@ -38,6 +38,29 @@
     "{\"config\":[{\"key\":\"httpsSelfUrl\",\"need_ca\":true},{\"key\":"                                               \
     "\"mqttsSelfUrl\",\"need_ca\":true}],\"env\":\"%s\"}"
 
+/**
+ * @brief Split register-center style "host" or "host:port"
+ * @param[in] url input host string
+ * @param[out] host output hostname buffer
+ * @param[in] host_len size of host buffer
+ * @return resolved port, 443 when url has no port suffix
+ */
+static uint16_t iotdns_split_host_port(const char *url, char *host, size_t host_len)
+{
+    unsigned int port = 443;
+
+    if (url == NULL || host == NULL || host_len == 0) {
+        return 443;
+    }
+
+    if (sscanf(url, "%63[^:]:%u", host, &port) >= 2 && port > 0 && port <= 65535) {
+        return (uint16_t)port;
+    }
+
+    snprintf(host, host_len, "%s", url);
+    return 443;
+}
+
 static int iotdns_response_decode(const uint8_t *input, size_t ilen, tuya_endpoint_t *endport)
 {
     cJSON *root = cJSON_Parse((const char *)input);
@@ -56,10 +79,19 @@ static int iotdns_response_decode(const uint8_t *input, size_t ilen, tuya_endpoi
     PR_DEBUG("httpsSelfUrl:%s", httpsSelfUrl);
     PR_DEBUG("mqttsSelfUrl:%s", mqttsSelfUrl);
 
-    /* ATOP url decode */
+    /* ATOP url decode: https://host[:port]/path */
     int port = 443;
-    sscanf(httpsSelfUrl, "https://%64[^/]%16[^\n]", endport->atop.host, endport->atop.path);
-    endport->atop.port = (uint16_t)port;
+    int n = 0;
+
+    endport->atop.path[0] = '\0';
+    n = sscanf(httpsSelfUrl, "https://%64[^:]:%hu%16[^\n]", endport->atop.host, &port, endport->atop.path);
+    if (n >= 2) {
+        endport->atop.port = (uint16_t)port;
+    } else {
+        port = 443;
+        sscanf(httpsSelfUrl, "https://%64[^/]%16[^\n]", endport->atop.host, endport->atop.path);
+        endport->atop.port = (uint16_t)port;
+    }
     PR_DEBUG("endport->atop.host = \"%s\"", endport->atop.host);
     PR_DEBUG("endport->atop.port = %d", endport->atop.port);
     PR_DEBUG("endport->atop.path = \"%s\"", endport->atop.path);
@@ -100,6 +132,9 @@ static int iotdns_response_decode(const uint8_t *input, size_t ilen, tuya_endpoi
 static int iotdns_base_request(char *body, char *path, http_client_response_t *http_response)
 {
     http_client_status_t http_status;
+    char rcs_host[MAX_LENGTH_TUYA_HOST + 1] = {0};
+    uint16_t rcs_port = 443;
+    const char *rcs_url = NULL;
 
     /* HTTP headers */
     http_client_header_t headers[] = {
@@ -110,6 +145,11 @@ static int iotdns_base_request(char *body, char *path, http_client_response_t *h
 
     register_center_t rcs;
     tuya_register_center_get(&rcs);
+    rcs_url = rcs.urlx ? rcs.urlx : rcs.url0;
+    if (rcs_url == NULL) {
+        return OPRT_INVALID_PARM;
+    }
+    rcs_port = iotdns_split_host_port(rcs_url, rcs_host, sizeof(rcs_host));
 
     /* HTTP Request send */
     PR_DEBUG("http request send!");
@@ -117,8 +157,8 @@ static int iotdns_base_request(char *body, char *path, http_client_response_t *h
         &(const http_client_request_t){
             .cacert = rcs.ca_cert,
             .cacert_len = rcs.ca_cert_len,
-            .host = rcs.urlx ? rcs.urlx : rcs.url0,
-            .port = 443,
+            .host = rcs_host,
+            .port = rcs_port,
             .method = "POST",
             .path = path,
             .headers = headers,
@@ -193,9 +233,18 @@ int iotdns_cloud_endpoint_get(const char *region, const char *env, tuya_endpoint
     uint8_t headers_count = sizeof(headers) / sizeof(http_client_header_t);
 
     http_client_response_t http_response = {0};
+    char rcs_host[MAX_LENGTH_TUYA_HOST + 1] = {0};
+    uint16_t rcs_port = 443;
+    const char *rcs_url = NULL;
 
     register_center_t rcs;
     tuya_register_center_get(&rcs);
+    rcs_url = rcs.urlx ? rcs.urlx : rcs.url0;
+    if (rcs_url == NULL) {
+        tal_free(body_buffer);
+        return OPRT_INVALID_PARM;
+    }
+    rcs_port = iotdns_split_host_port(rcs_url, rcs_host, sizeof(rcs_host));
 
     /* HTTP Request send */
     PR_DEBUG("http request send!");
@@ -203,8 +252,8 @@ int iotdns_cloud_endpoint_get(const char *region, const char *env, tuya_endpoint
         &(const http_client_request_t){
             .cacert = rcs.ca_cert,
             .cacert_len = rcs.ca_cert_len,
-            .host = rcs.urlx ? rcs.urlx : rcs.url0,
-            .port = 443,
+            .host = rcs_host,
+            .port = rcs_port,
             .method = "POST",
             .path = "/v2/url_config",
             .headers = headers,

--- a/src/tuya_cloud_service/cloud/iotdns.c
+++ b/src/tuya_cloud_service/cloud/iotdns.c
@@ -84,7 +84,7 @@ static int iotdns_response_decode(const uint8_t *input, size_t ilen, tuya_endpoi
     int n = 0;
 
     endport->atop.path[0] = '\0';
-    n = sscanf(httpsSelfUrl, "https://%64[^:]:%hu%16[^\n]", endport->atop.host, &port, endport->atop.path);
+    n = sscanf(httpsSelfUrl, "https://%64[^:]:%d%16[^\n]", endport->atop.host, &port, endport->atop.path);
     if (n >= 2) {
         endport->atop.port = (uint16_t)port;
     } else {


### PR DESCRIPTION
Split register-center host:port for HTTP requests and decode optional port from httpsSelfUrl so non-443 endpoints connect correctly.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
