### PR TITLE
feat(T5AI): add generic T5AI_MODULE board

### DIFF
--- a/boards/T5AI/Kconfig
+++ b/boards/T5AI/Kconfig
@@ -106,6 +106,12 @@ choice
             rsource "./TUYA_T5AI_EINK_NFC/Kconfig"
         endif
 
+    config BOARD_CHOICE_T5AI_MODULE
+        bool "T5AI_MODULE"
+        if (BOARD_CHOICE_T5AI_MODULE)
+            rsource "./T5AI_MODULE/Kconfig"
+        endif
+
 # <new-board-add: This line cannot be deleted or modified>
 
 endchoice

--- a/boards/T5AI/T5AI_MODULE/CMakeLists.txt
+++ b/boards/T5AI/T5AI_MODULE/CMakeLists.txt
@@ -1,0 +1,44 @@
+##
+# @file CMakeLists.txt
+# @brief
+#/
+
+# MODULE_PATH
+set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# MODULE_NAME
+get_filename_component(MODULE_NAME ${MODULE_PATH} NAME)
+
+# LIB_SRCS
+aux_source_directory(${MODULE_PATH} LIB_SRCS)
+
+# LIB_PUBLIC_INC
+set(LIB_PUBLIC_INC ${MODULE_PATH})
+
+
+########################################
+# Target Configure
+########################################
+add_library(${MODULE_NAME})
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        ${LIB_SRCS}
+    )
+
+target_include_directories(${MODULE_NAME}
+    PRIVATE
+        ${LIB_PRIVATE_INC}
+
+    PUBLIC
+        ${LIB_PUBLIC_INC}
+    )
+
+
+########################################
+# Layer Configure
+########################################
+list(APPEND COMPONENT_LIBS ${MODULE_NAME})
+set(COMPONENT_LIBS "${COMPONENT_LIBS}" PARENT_SCOPE)
+list(APPEND COMPONENT_PUBINC ${LIB_PUBLIC_INC})
+set(COMPONENT_PUBINC "${COMPONENT_PUBINC}" PARENT_SCOPE)

--- a/boards/T5AI/T5AI_MODULE/Kconfig
+++ b/boards/T5AI/T5AI_MODULE/Kconfig
@@ -1,0 +1,11 @@
+config CHIP_CHOICE
+    string
+    default "T5AI"
+
+config BOARD_CHOICE
+    string
+    default "T5AI_MODULE"
+
+config BOARD_CONFIG
+    bool
+    default y

--- a/boards/T5AI/T5AI_MODULE/board_com_api.h
+++ b/boards/T5AI/T5AI_MODULE/board_com_api.h
@@ -1,0 +1,41 @@
+/**
+ * @file board_com_api.h
+ * @author Tuya Inc.
+ * @brief Header file for common board-level hardware registration APIs.
+ *
+ * @copyright Copyright (c) 2021-2025 Tuya Inc. All Rights Reserved.
+ */
+
+#ifndef __BOARD_COM_API_H__
+#define __BOARD_COM_API_H__
+
+#include "tuya_cloud_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***********************************************************
+************************macro define************************
+***********************************************************/
+
+/***********************************************************
+***********************typedef define***********************
+***********************************************************/
+
+/***********************************************************
+********************function declaration********************
+***********************************************************/
+
+/**
+ * @brief Registers all the hardware peripherals on the board.
+ *
+ * @return Returns OPERATE_RET_OK on success, or an appropriate error code on failure.
+ */
+OPERATE_RET board_register_hardware(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARD_COM_API_H__ */

--- a/boards/T5AI/T5AI_MODULE/t5ai_module.c
+++ b/boards/T5AI/T5AI_MODULE/t5ai_module.c
@@ -1,0 +1,47 @@
+/**
+ * @file t5ai.c
+ * @brief Generic T5AI module board. No peripherals are registered on this board.
+ * @version 0.1
+ * @copyright Copyright (c) 2021-2025 Tuya Inc. All Rights Reserved.
+ */
+
+#include "tuya_cloud_types.h"
+
+#include "tal_api.h"
+
+#include "board_com_api.h"
+
+/***********************************************************
+************************macro define************************
+***********************************************************/
+
+/***********************************************************
+***********************typedef define***********************
+***********************************************************/
+
+/***********************************************************
+********************function declaration********************
+***********************************************************/
+
+/***********************************************************
+***********************variable define**********************
+***********************************************************/
+
+/***********************************************************
+***********************function define**********************
+***********************************************************/
+
+/**
+ * @brief Registers all the hardware peripherals on the board.
+ *
+ * @note This board represents the generic T5AI module and has no peripherals,
+ *       so this function does nothing and simply returns success.
+ *
+ * @return Returns OPERATE_RET_OK on success, or an appropriate error code on failure.
+ */
+OPERATE_RET board_register_hardware(void)
+{
+    OPERATE_RET rt = OPRT_OK;
+
+    return rt;
+}


### PR DESCRIPTION
Add a T5AI_MODULE board representing the generic T5AI module with no peripherals registered. Not set as the default board (default stays TUYA_T5AI_BOARD).

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
