### PR TITLE
fix(apps): make app CMakeLists out-of-tree build safe

### DIFF
--- a/apps/tuya.ai/your_chat_bot/CMakeLists.txt
+++ b/apps/tuya.ai/your_chat_bot/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(${EXAMPLE_LIB}
 ########################################
 # Generate language config header
 ########################################
-add_subdirectory(${APP_PATH}/src/display2)
+add_subdirectory(${APP_PATH}/src/display2 ${CMAKE_BINARY_DIR}/app_display2)
 
 
 else()
@@ -62,7 +62,7 @@ target_include_directories(${EXAMPLE_LIB}
 ########################################
 
 if (CONFIG_ENABLE_BATTERY STREQUAL "y")
-    add_subdirectory(${APP_PATH}/src/battery)
+    add_subdirectory(${APP_PATH}/src/battery ${CMAKE_BINARY_DIR}/app_battery)
 endif()
 
 

--- a/apps/tuya.ai/your_robot_dog/CMakeLists.txt
+++ b/apps/tuya.ai/your_robot_dog/CMakeLists.txt
@@ -59,7 +59,7 @@ target_compile_options(${EXAMPLE_LIB}
 ########################################
 
 if (CONFIG_ENABLE_COMP_AI_DISPLAY STREQUAL "y")
-    add_subdirectory(${APP_PATH}/src/display)
+    add_subdirectory(${APP_PATH}/src/display ${CMAKE_BINARY_DIR}/app_display)
 endif()
 
 

--- a/apps/tuya.ai/your_serial_chat_bot/CMakeLists.txt
+++ b/apps/tuya.ai/your_serial_chat_bot/CMakeLists.txt
@@ -39,6 +39,6 @@ target_include_directories(${EXAMPLE_LIB}
 ########################################
 
 if (CONFIG_ENABLE_BATTERY STREQUAL "y")
-    add_subdirectory(${APP_PATH}/src/battery)
+    add_subdirectory(${APP_PATH}/src/battery ${CMAKE_BINARY_DIR}/app_battery)
 endif()
 

--- a/apps/tuya_t5_pocket/tuya_t5_pocket_ai/CMakeLists.txt
+++ b/apps/tuya_t5_pocket/tuya_t5_pocket_ai/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(${EXAMPLE_LIB}
         ${APP_PATH}/include
 )
 
-add_subdirectory(${APP_PATH}/src/display)
+add_subdirectory(${APP_PATH}/src/display ${CMAKE_BINARY_DIR}/app_display)
 
 else()
 ########################################
@@ -67,8 +67,8 @@ target_compile_options(${EXAMPLE_LIB}
 # Add subdirectory
 ########################################
 
-add_subdirectory(${APP_PATH}/src/display)
-add_subdirectory(${APP_PATH}/src/expand)
+add_subdirectory(${APP_PATH}/src/display ${CMAKE_BINARY_DIR}/app_display)
+add_subdirectory(${APP_PATH}/src/expand ${CMAKE_BINARY_DIR}/app_expand)
 
 
 

--- a/examples/tflite/tflite-helloworld/CMakeLists.txt
+++ b/examples/tflite/tflite-helloworld/CMakeLists.txt
@@ -39,4 +39,4 @@ target_compile_options(${EXAMPLE_LIB}
         ${APP_OPTIONS}
     )
 
-add_subdirectory(${APP_PATH}/tflite)
+add_subdirectory(${APP_PATH}/tflite ${CMAKE_BINARY_DIR}/app_tflite)


### PR DESCRIPTION
add_subdirectory() with an absolute ${APP_PATH}/... source dir needs an explicit binary directory when the app is built out-of-tree (copied into a project's source/embedded and include()'d by the SDK from outside the SDK source tree). Otherwise CMake errors: "add_subdirectory not given a binary directory ... is not a subdirectory of ...".

Give each such call a unique ${CMAKE_BINARY_DIR}/app_<name> binary dir:
- apps/tuya.ai/your_chat_bot (display2, battery)
- apps/tuya.ai/your_robot_dog (display)
- apps/tuya.ai/your_serial_chat_bot (battery)
- apps/tuya_t5_pocket/tuya_t5_pocket_ai (display x2 exclusive branches, expand)
- examples/tflite/tflite-helloworld (tflite)

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
