### PR TITLE
feat(cli): support app-private esp-idf components + bump ESP32 platform

### DIFF
--- a/platform/platform_config.yaml
+++ b/platform/platform_config.yaml
@@ -22,7 +22,7 @@ platforms:
 - name: ESP32
   repo: https://github.com/tuya/TuyaOpen-esp32
   branch: master
-  commit: 2c6d39993489351844c915856fe55e3e80fefb9e
+  commit: 012b6009d024f83986c1ec1c9bd3a3bfe8ed5e85
 
 - name: LN882H
   repo: https://github.com/tuya/TuyaOpen-ln882h

--- a/tools/cli_command/cli_build.py
+++ b/tools/cli_command/cli_build.py
@@ -195,6 +195,26 @@ def cmake_configure(using_data, verbose=False):
     framework = using_data.get("CONFIG_FRAMEWORK_CHOICE", "")
     chip_name = using_data.get("CONFIG_CHIP_CHOICE", "")
     board_name = using_data.get("CONFIG_BOARD_CHOICE", "")
+    # Expose an app's private esp-idf components to the platform build via the
+    # TUYAOS_EXTRA_COMPONENT_DIRS env var, consumed only by ESP32's
+    # platform/ESP32/tuya_open_sdk/CMakeLists.txt (each root is appended to
+    # EXTRA_COMPONENT_DIRS, so every subdir under it becomes an esp-idf
+    # component). Convention over configuration: an app just drops components
+    # under <app_root>/esp_components (esp-prefixed since this is ESP32-only —
+    # esp-idf's own components/ dir doesn't reach the app, as the idf "project"
+    # is tuya_open_sdk, not the app). We merge rather than overwrite so a
+    # caller/CI can pre-export extra roots. Gated on ESP32; joined with spaces
+    # to match the receiver's split.
+    if platform_name == "ESP32":
+        comp_roots = []
+        existing = os.environ.get("TUYAOS_EXTRA_COMPONENT_DIRS", "").strip()
+        if existing:
+            comp_roots.extend(existing.split())
+        conv_dir = os.path.join(app_root, "esp_components")
+        if os.path.isdir(conv_dir) and conv_dir not in comp_roots:
+            comp_roots.append(conv_dir)
+        if comp_roots:
+            os.environ["TUYAOS_EXTRA_COMPONENT_DIRS"] = " ".join(comp_roots)
     defines = [
         f"-DTOS_PROJECT_NAME={project_name}",
         f"-DTOS_PROJECT_ROOT={app_root}",


### PR DESCRIPTION
cli_build.py: when building for ESP32, expose <app_root>/esp_components to the platform build via the TUYAOS_EXTRA_COMPONENT_DIRS env var (consumed by platform/ESP32/tuya_open_sdk/CMakeLists.txt, which appends each root to EXTRA_COMPONENT_DIRS so every subdir becomes an esp-idf component). This is convention-over-configuration: an app just drops components under esp_components/ with no Kconfig or config key. Merges with any pre-exported value rather than overwriting, so CI/callers can add extra roots. Gated on the ESP32 platform.

platform_config.yaml: bump ESP32 pin to 012b6009 (TuyaOpen-esp32 master), which carries the matching TUYAOS_EXTRA_COMPONENT_DIRS consumer and the adapter include-dir glob.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
