### PR TITLE
fix(export): check git availability as hard dependency

### DIFF
--- a/export.bat
+++ b/export.bat
@@ -55,6 +55,20 @@ if !errorlevel! neq 0 (
 )
 
 :: ---------------------------------------------------------------------------
+:: git is a hard dependency (platform updates, submodules, version detection)
+:: ---------------------------------------------------------------------------
+where git >nul 2>&1
+if !errorlevel! neq 0 (
+    echo [TuyaOpen] Error: Git - git not found. It may not be installed.
+    echo Next:
+    echo   Open a new terminal and run: winget install Git.Git
+    echo   ^(or download from https://git-scm.com/downloads^)
+    echo   Then restart this terminal and re-run: export.bat
+    pause
+    exit /b 1
+)
+
+:: ---------------------------------------------------------------------------
 :: Guard active (Stage 2): already active → print hint and exit
 :: ---------------------------------------------------------------------------
 if "%TUYAOPEN_ENV_ACTIVE%"=="1" (

--- a/export.ps1
+++ b/export.ps1
@@ -227,7 +227,7 @@ function Invoke-TuyaUvNative {
 
 function Write-TuyaOpenFailureHint {
     param(
-        [ValidateSet('Entry', 'Uv', 'Python', 'Venv', 'Sync', 'Session', 'Io')]
+        [ValidateSet('Entry', 'Uv', 'Python', 'Venv', 'Sync', 'Session', 'Io', 'Git')]
         [string]$Stage,
         [string]$Summary,
         [string]$Cause,
@@ -314,6 +314,19 @@ function Test-TuyaProjectFiles {
     }
     if ($missing.Count -eq 0) { return $true }
     Write-TuyaOpenFailureHint -Stage Entry -Summary 'Required project files are missing.' -Cause ($missing -join ', ') -NextSteps @('Use a complete TuyaOpen clone.', "Missing under: $Root")
+    return $false
+}
+
+function Test-TuyaGitAvailable {
+    # git is a hard dependency: platform updates, submodule downloads and version
+    # detection all rely on it. GitPython also fails at import time without it.
+    $cmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($cmd) { return $true }
+    Write-TuyaOpenFailureHint -Stage Git -Summary 'git not found. It may not be installed.' -NextSteps @(
+        'Open a new terminal and run: winget install Git.Git',
+        '(or download from https://git-scm.com/downloads)',
+        'Then restart your terminal and re-run: . .\export.ps1'
+    )
     return $false
 }
 
@@ -2048,6 +2061,7 @@ $openRoot = $env:OPEN_SDK_ROOT
 
 try {
     if (-not (Test-TuyaProjectFiles -Root $openRoot)) { Stop-TuyaOpenExport 1 }
+    if (-not (Test-TuyaGitAvailable)) { Stop-TuyaOpenExport 1 }
     Set-Location $openRoot
 
     if (Invoke-TuyaGuardActive -Root $openRoot) { return }

--- a/export.sh
+++ b/export.sh
@@ -468,7 +468,7 @@ tuya_cleanup() {
              tuya_uv_run_stream tuya_on_uv_sync_line \
              tuya_parse_uv_sync_line tuya_parse_python_install_line \
              tuya_export_cold_start_kind tuya_write_cold_start_hint \
-             tuya_export_cold_start \
+             tuya_export_cold_start tuya_check_git \
              tuya_human_size tuya_cleanup 2>/dev/null || true
 }
 
@@ -556,6 +556,19 @@ if [ -n "$_tuya_missing" ]; then
     return 1
 fi
 unset _tuya_missing
+
+# ---------------------------------------------------------------------------
+# Git availability (hard dependency: platform update / submodules / version)
+# ---------------------------------------------------------------------------
+tuya_check_git() {
+    if tuya_has_cmd git; then
+        return 0
+    fi
+    tuya_error Git 'git not found. It may not be installed.' \
+        'Open a terminal and install, e.g.: sudo apt install git  (or: brew install git)' \
+        'Then restart your terminal and re-run: . ./export.sh'
+    return 1
+}
 
 # ---------------------------------------------------------------------------
 # Git version banner
@@ -1624,6 +1637,7 @@ fi
 tuya_guard_active   && { tuya_cleanup; return 0; }
 tuya_write_cold_start_hint "$(tuya_export_cold_start_kind)"
 tuya_detect_region
+tuya_check_git      || { tuya_cleanup; return 1; }
 tuya_setup_uv       || { tuya_cleanup; return 1; }
 tuya_setup_python   || { tuya_cleanup; return 1; }
 tuya_setup_venv     || { tuya_cleanup; return 1; }


### PR DESCRIPTION
git is required for platform updates, submodule downloads and version detection, and GitPython fails at import time without a git executable on PATH. Add an early availability check to export.bat/ps1/sh that fails fast with install guidance (winget/apt/brew) instead of a confusing later failure.
