### PR TITLE
fix(export): clear inherited PYTHONHOME during env bootstrap

### DIFF
--- a/export.ps1
+++ b/export.ps1
@@ -1973,6 +1973,10 @@ function Register-TuyaOpenCommandHelpers {
         Remove-Item Env:OPEN_SDK_MAKE      -ErrorAction SilentlyContinue
         Remove-Item Env:OPEN_SDK_UV        -ErrorAction SilentlyContinue
         Remove-Item Env:TUYAOPEN_ENV_ACTIVE -ErrorAction SilentlyContinue
+        if ($env:_OLD_TUYA_PYTHONHOME) {
+            $env:PYTHONHOME = $env:_OLD_TUYA_PYTHONHOME
+            Remove-Item Env:_OLD_TUYA_PYTHONHOME -ErrorAction SilentlyContinue
+        }
         Restore-TuyaOpenPrompt
         Remove-Item 'function:\tos.py'     -Force -ErrorAction SilentlyContinue
         Remove-Item 'function:\deactivate' -Force -ErrorAction SilentlyContinue
@@ -1987,6 +1991,15 @@ function Register-TuyaOpenCommandHelpers {
 
 function Invoke-TuyaExportSetupCore {
     param([Parameter(Mandatory)][string]$Root)
+    # An inherited PYTHONHOME (conda or another Python distribution active in
+    # the launching shell) breaks startup of every python this script and the
+    # venv run. Clear it like a standard venv activate does; deactivate
+    # restores it.
+    if ($env:PYTHONHOME) {
+        $env:_OLD_TUYA_PYTHONHOME = $env:PYTHONHOME
+        Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
+        Write-TuyaOpenDebug '[TuyaOpen] Cleared inherited PYTHONHOME (deactivate restores it).'
+    }
     $coldKind = Get-TuyaExportColdStartKind -Root $Root
     Write-TuyaExportColdStartHint -Kind $coldKind
     Invoke-TuyaRegionDetect
@@ -2040,6 +2053,7 @@ function Write-TuyaCmdEnvBat {
         "set `"OPEN_SDK_MAKE_BIN=$($env:OPEN_SDK_MAKE_BIN)`"",
         "set `"OPEN_SDK_MAKE=$($env:OPEN_SDK_MAKE)`"",
         "set `"VIRTUAL_ENV=$($env:VIRTUAL_ENV)`"",
+        'set "PYTHONHOME="',
         'set "TUYAOPEN_ENV_ACTIVE=1"'
     ) | Set-Content -LiteralPath $OutputPath -Encoding ASCII
 }

--- a/export.sh
+++ b/export.sh
@@ -1496,6 +1496,18 @@ tuya_platform_banner() {
     tuya_info "Host: $(uname -s) $(uname -m) | uv $uv_ver | Python $TUYA_PYTHON_VERSION"
 }
 
+tuya_clear_pythonhome() {
+    # An inherited PYTHONHOME (conda or another Python distribution active in
+    # the launching shell) breaks startup of every python this script and the
+    # venv run. Clear it like a standard venv activate does; deactivate
+    # restores it.
+    if [ -n "${PYTHONHOME:-}" ]; then
+        _OLD_TUYA_PYTHONHOME="$PYTHONHOME"
+        unset PYTHONHOME
+        tuya_debug '[TuyaOpen] Cleared inherited PYTHONHOME (deactivate restores it).'
+    fi
+}
+
 tuya_set_env() {
     local venv_py="${_tuya_venv_py:-}"
     local venv_path="$OPEN_SDK_ROOT/.venv"
@@ -1570,6 +1582,11 @@ tuya_teardown() {
         tuya_path_remove "$uv_dir"
     fi
     unset VIRTUAL_ENV OPEN_SDK_ROOT OPEN_SDK_PYTHON OPEN_SDK_PIP OPEN_SDK_UV OPEN_SDK_MAKE_BIN OPEN_SDK_MAKE TUYAOPEN_ENV_ACTIVE
+    if [ -n "${_OLD_TUYA_PYTHONHOME:-}" ]; then
+        PYTHONHOME="$_OLD_TUYA_PYTHONHOME"
+        export PYTHONHOME
+        unset _OLD_TUYA_PYTHONHOME
+    fi
     if [ -n "${BASH_VERSION:-}" ] && [ -n "${_OLD_TUYA_PS1:-}" ]; then
         PS1="$_OLD_TUYA_PS1"
         unset _OLD_TUYA_PS1
@@ -1635,6 +1652,7 @@ if [ -n "${BASH_SOURCE[0]:-}" ] && [ "${BASH_SOURCE[0]}" = "$0" ]; then
 fi
 
 tuya_guard_active   && { tuya_cleanup; return 0; }
+tuya_clear_pythonhome
 tuya_write_cold_start_hint "$(tuya_export_cold_start_kind)"
 tuya_detect_region
 tuya_check_git      || { tuya_cleanup; return 1; }

--- a/tests/export/test_export.sh
+++ b/tests/export/test_export.sh
@@ -422,6 +422,31 @@ assert_contains 'guard_active: active prints re-activate hint' \
     "$guard_active_out" 'To re-activate:'
 
 # ---------------------------------------------------------------------------
+# 5b. PYTHONHOME hygiene
+# ---------------------------------------------------------------------------
+section 'PYTHONHOME hygiene'
+
+# An inherited PYTHONHOME (conda / another Python install active in the
+# launching shell) breaks startup of every python the export flow runs.
+# tuya_clear_pythonhome must clear it (saving the old value) and
+# tuya_teardown must restore it, mirroring standard venv activate scripts.
+pythonhome_out=""
+pythonhome_out=$(bash --norc --noprofile <<PYHOME_EOF
+ROOT='$ROOT'
+export PYTHONHOME=/foreign/python
+TUYAOPEN_EXPORT_SKIP_MAIN=1 . "\$ROOT/export.sh"
+tuya_clear_pythonhome
+[ -z "\${PYTHONHOME:-}" ] && echo "CLEARED=1"
+[ "\${_OLD_TUYA_PYTHONHOME:-}" = '/foreign/python' ] && echo "SAVED=1"
+tuya_teardown --silent 2>/dev/null
+[ "\${PYTHONHOME:-}" = '/foreign/python' ] && echo "RESTORED=1"
+PYHOME_EOF
+)
+assert_contains 'pythonhome: cleared for the session' "$pythonhome_out" 'CLEARED=1'
+assert_contains 'pythonhome: old value saved' "$pythonhome_out" 'SAVED=1'
+assert_contains 'pythonhome: restored by teardown' "$pythonhome_out" 'RESTORED=1'
+
+# ---------------------------------------------------------------------------
 # 6. Full integration (subshell)
 # ---------------------------------------------------------------------------
 section 'Full integration'


### PR DESCRIPTION
### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
