### PR TITLE
fix(export): uv venv lock contention handling and warm-start sync skip

### DIFF
--- a/export.ps1
+++ b/export.ps1
@@ -1667,6 +1667,23 @@ function Complete-TuyaUvSyncProgress {
     }
 }
 
+function Write-TuyaUvLockContentionHint {
+    <#
+        uv serializes .venv access via an OS-level lock on .venv\.lock and waits
+        for a busy lock silently (nothing is printed without -v), which looks
+        like a hang. A leftover .lock FILE after a crash is normal and harmless;
+        only a live uv process holding the lock blocks us.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$Reason
+    )
+    Write-TuyaOpenInfo "[TuyaOpen] $Reason"
+    Write-TuyaOpenInfo "           uv waits silently for the venv lock: $(Join-Path $Root '.venv\.lock')"
+    Write-TuyaOpenInfo '           Likely another TuyaOpen/uv session holds it. Check: Get-Process uv'
+    Write-TuyaOpenInfo '           Close other sessions or stop stray uv processes, then re-run: . .\export.ps1'
+}
+
 function Invoke-TuyaUvSyncWithProgress {
     param(
         [Parameter(Mandatory)][string]$UvExe,
@@ -1675,6 +1692,10 @@ function Invoke-TuyaUvSyncWithProgress {
     )
 
     Reset-TuyaUvDiag
+    $priorUv = @(Get-Process -Name uv -ErrorAction SilentlyContinue)
+    if ($priorUv.Count -gt 0) {
+        Write-TuyaUvLockContentionHint -Root $Root -Reason "Another uv process is already running (PID: $($priorUv.Id -join ', ')); dependency sync may pause until it finishes."
+    }
     $syncPlan = Get-TuyaUvSyncPlan
     $syncSrc = if ($syncPlan.UseAliyunMirror) { 'Aliyun PyPI mirror (CN)' } else { 'PyPI (default)' }
     Write-TuyaOpenInfo "[TuyaOpen] Syncing $TotalPackages Python dependencies from $syncSrc..."
@@ -1700,18 +1721,31 @@ function Invoke-TuyaUvSyncWithProgress {
         $env:UV_NO_PROGRESS = '1'
 
         $uvLines = [System.Collections.Generic.List[string]]::new()
+        # A sync blocked on the venv lock produces no output at all: watch for
+        # total silence after start and explain the wait once (see hint above).
+        $lockWatch = @{ StartedAt = [datetime]::UtcNow; GotOutput = $false; Warned = $false }
         $onUvLine = {
             param($line)
+            $lockWatch.GotOutput = $true
             if (-not $line) { return }
             $uvLines.Add($line)
             Add-TuyaUvDiagLine -Line $line
             Update-TuyaUvSyncFromUvLine -Line $line -TotalPackages $TotalPackages -State $progressState
         }
+        $onLockPoll = {
+            if ($lockWatch.Warned -or $lockWatch.GotOutput) { return }
+            if (([datetime]::UtcNow - $lockWatch.StartedAt).TotalSeconds -lt 10) { return }
+            $lockWatch.Warned = $true
+            if ($progressState.UseInline -and $progressState.Started -and -not $progressState.NewlineDone) {
+                Write-Host ''
+            }
+            Write-TuyaUvLockContentionHint -Root $Root -Reason 'uv sync has produced no output for 10+ seconds; it may be waiting to acquire the venv lock.'
+        }
 
         try {
             Write-TuyaUvSyncProgressUpdate -Current 0 -Total $TotalPackages -State $progressState
             $exitCode = Invoke-TuyaProcessStreamLines -Exe $UvExe -ArgumentList $syncArgs `
-                -WorkingDirectory $Root -OnLine $onUvLine
+                -WorkingDirectory $Root -OnLine $onUvLine -OnPoll $onLockPoll
             if ($exitCode -ne 0 -and $uvLines.Count -gt 0) {
                 Write-TuyaOpenInfo '[TuyaOpen] uv sync output:'
                 foreach ($uvLine in $uvLines) {
@@ -1794,6 +1828,7 @@ function Invoke-TuyaSetupVenv {
     $venvPath = Join-Path $Root '.venv'
     $venvPy   = Join-Path $venvPath 'Scripts\python.exe'
     $marker   = Get-TuyaVenvMarkerPath -VenvPath $venvPath
+    $createdVenv = $false
 
     if (-not (Test-TuyaUvManagedVenv -VenvPath $venvPath) -or -not (Test-Path -LiteralPath $venvPy -PathType Leaf)) {
         Write-TuyaOpenInfo '[TuyaOpen] Creating .venv...'
@@ -1810,28 +1845,50 @@ function Invoke-TuyaSetupVenv {
             Write-TuyaOpenFailureHint -Stage Venv -Summary 'Cannot write venv marker.' -Cause $marker -NextSteps @('Check .venv permissions', 'Re-run: . .\export.ps1')
             Stop-TuyaOpenExport 1
         }
+        $createdVenv = $true
         Write-TuyaOpenDebug '[TuyaOpen] .venv created.'
     }
 
-    Push-Location $Root
-    try {
-        Write-TuyaOpenStage -StageId 'sync'
-        $pkgCount = Get-TuyaUvLockPackageCount -LockPath (Join-Path $Root 'uv.lock')
-        $syncRc = Invoke-TuyaUvSyncWithProgress -UvExe $UvExe -Root $Root -TotalPackages $pkgCount
-        if ($syncRc -ne 0) {
-            $cause = 'uv sync --frozen failed.'
-            if ($script:TuyaUvDiag.Count -gt 0) {
-                if (Test-TuyaUvDiagIsNetwork) {
-                    $cause = 'network error while syncing dependencies (check connection/proxy; see uv sync output above)'
-                } else {
-                    $cause = 'dependency resolution or uv sync failed (see uv sync output above)'
-                }
-            }
-            Write-TuyaOpenFailureHint -Stage Sync -Summary 'Dependency sync failed.' -Cause $cause -NextSteps @('Ensure uv.lock matches pyproject.toml', 'Check network, then re-run: . .\export.ps1')
-            Stop-TuyaOpenExport 1
+    # Warm start: skip sync when uv.lock has not changed since the last
+    # successful sync (the marker mtime is refreshed after each sync). This
+    # keeps re-sourcing fast and avoids re-acquiring the venv lock every time.
+    # TUYAOPEN_EXPORT_VERBOSE=1 forces a full sync (self-repair escape hatch).
+    $needSync = $true
+    if (-not $createdVenv -and -not $script:TuyaOpenVerbose) {
+        $lockStamp = $null
+        $markerStamp = $null
+        try { $lockStamp   = (Get-Item -LiteralPath (Join-Path $Root 'uv.lock') -ErrorAction Stop).LastWriteTimeUtc } catch {}
+        try { $markerStamp = (Get-Item -LiteralPath $marker -ErrorAction Stop).LastWriteTimeUtc } catch {}
+        if ($null -ne $lockStamp -and $null -ne $markerStamp -and $lockStamp -le $markerStamp) {
+            $needSync = $false
         }
-        Write-TuyaOpenDebug '[TuyaOpen] Dependencies synced.'
-    } finally { Pop-Location }
+    }
+
+    if ($needSync) {
+        Push-Location $Root
+        try {
+            Write-TuyaOpenStage -StageId 'sync'
+            $pkgCount = Get-TuyaUvLockPackageCount -LockPath (Join-Path $Root 'uv.lock')
+            $syncRc = Invoke-TuyaUvSyncWithProgress -UvExe $UvExe -Root $Root -TotalPackages $pkgCount
+            if ($syncRc -ne 0) {
+                $cause = 'uv sync --frozen failed.'
+                if ($script:TuyaUvDiag.Count -gt 0) {
+                    if (Test-TuyaUvDiagIsNetwork) {
+                        $cause = 'network error while syncing dependencies (check connection/proxy; see uv sync output above)'
+                    } else {
+                        $cause = 'dependency resolution or uv sync failed (see uv sync output above)'
+                    }
+                }
+                Write-TuyaOpenFailureHint -Stage Sync -Summary 'Dependency sync failed.' -Cause $cause -NextSteps @('Ensure uv.lock matches pyproject.toml', 'Check network, then re-run: . .\export.ps1')
+                Stop-TuyaOpenExport 1
+            }
+            Write-TuyaOpenDebug '[TuyaOpen] Dependencies synced.'
+        } finally { Pop-Location }
+        try { (Get-Item -LiteralPath $marker -ErrorAction Stop).LastWriteTimeUtc = [datetime]::UtcNow } catch {}
+    } else {
+        Write-TuyaOpenStage -StageId 'sync'
+        Write-TuyaOpenInfo '[TuyaOpen] Python dependencies up to date (uv.lock unchanged); skipping sync.'
+    }
 
     if (-not (Test-Path -LiteralPath $venvPy -PathType Leaf)) {
         Write-TuyaOpenFailureHint -Stage Sync -Summary '.venv Python missing after sync.' -Cause $venvPy -NextSteps @('Remove .venv and re-run: . .\export.ps1')

--- a/export.ps1
+++ b/export.ps1
@@ -2135,7 +2135,13 @@ try {
     if (-not (Test-TuyaGitAvailable)) { Stop-TuyaOpenExport 1 }
     Set-Location $openRoot
 
-    if (Invoke-TuyaGuardActive -Root $openRoot) { return }
+    if (Invoke-TuyaGuardActive -Root $openRoot) {
+        # Env vars may be inherited from a parent process, but functions are
+        # session-local: re-register tos.py / deactivate so this shell works.
+        Register-TuyaOpenCommandHelpers
+        Install-TuyaOpenPromptIndicator
+        return
+    }
 
     $venvPython = Invoke-TuyaExportSetupCore -Root $openRoot
     Register-TuyaOpenCommandHelpers

--- a/export.sh
+++ b/export.sh
@@ -233,6 +233,18 @@ tuya_uv_print_diag() {
     done
 }
 
+tuya_warn_uv_lock_contention() {
+    # uv serializes environment access via OS-level file locks (e.g. .venv/.lock)
+    # and waits for a busy lock silently (nothing is printed without -v), which
+    # looks like a hang. A leftover lock FILE after a crash is normal and
+    # harmless; only a live uv process holding the lock blocks us.
+    local reason="$1"
+    tuya_info "[TuyaOpen] $reason"
+    tuya_info "           uv waits silently for its file lock (e.g. $OPEN_SDK_ROOT/.venv/.lock)."
+    tuya_info '           Likely another TuyaOpen/uv session holds it. Check: pgrep -x uv'
+    tuya_info '           Close other sessions or stop stray uv processes, then re-run: . ./export.sh'
+}
+
 tuya_uv_run_stream() {
     # Run OPEN_SDK_UV with streaming line-by-line callback and correct exit code.
     # Uses a FIFO so the while loop runs in the current shell (variable mutations
@@ -253,11 +265,36 @@ tuya_uv_run_stream() {
     if mkfifo "$fifo" 2>/dev/null; then
         "$OPEN_SDK_UV" "$@" >"$fifo" 2>&1 &
         uv_pid=$!
+        # uv runs as a background job, so Ctrl+C in the sourcing shell never
+        # reaches it: it would keep running and hold the environment lock,
+        # silently blocking every later sync. Kill it on INT/TERM (existing
+        # user traps are restored afterwards where `trap -p` is available).
+        _tuya_saved_traps=$(trap -p INT TERM 2>/dev/null || true)
+        trap 'kill -TERM "$uv_pid" 2>/dev/null || true' INT TERM
+        # A run blocked on a busy uv lock produces no output at all: the
+        # sentinel file marks the first output line; a one-shot background
+        # watchdog explains total silence after 10 seconds.
+        _tuya_uv_sentinel="$fifo.out"
+        rm -f "$_tuya_uv_sentinel" 2>/dev/null || true
+        (
+            sleep 10
+            [ -e "$_tuya_uv_sentinel" ] && exit 0
+            kill -0 "$uv_pid" 2>/dev/null || exit 0
+            tuya_warn_uv_lock_contention 'uv has produced no output for 10+ seconds; it may be waiting to acquire a lock held by another uv process.'
+        ) &
+        _tuya_uv_watchdog=$!
         while IFS= read -r line; do
+            [ -e "$_tuya_uv_sentinel" ] || : > "$_tuya_uv_sentinel"
             tuya_uv_capture_diag "$line"
             [ -n "$line" ] && "$on_line" "$line"
         done <"$fifo"
         wait "$uv_pid" || rc=$?
+        kill "$_tuya_uv_watchdog" 2>/dev/null || true
+        wait "$_tuya_uv_watchdog" 2>/dev/null || true
+        trap - INT TERM
+        [ -n "$_tuya_saved_traps" ] && eval "$_tuya_saved_traps" 2>/dev/null
+        rm -f "$_tuya_uv_sentinel" 2>/dev/null || true
+        unset _tuya_saved_traps _tuya_uv_sentinel _tuya_uv_watchdog
         rm -f "$fifo" 2>/dev/null || true
     else
         tmp=$(mktemp 2>/dev/null || printf '%s' "/tmp/tuya_uv_stream_$$")
@@ -456,6 +493,7 @@ tuya_cleanup() {
              tuya_test_python_exe tuya_install_python tuya_install_python_ide \
              tuya_run_python_install tuya_python_install_error \
              tuya_uv_reset_diag tuya_uv_capture_diag tuya_uv_diag_is_network tuya_uv_print_diag \
+             tuya_warn_uv_lock_contention tuya_file_mtime_epoch \
              tuya_setup_python tuya_uv_sync_plan tuya_uv \
              tuya_lock_pkg_count tuya_sync_deps tuya_sync_deps_ide tuya_sync_deps_error \
              tuya_is_uv_venv tuya_migrate_legacy_venv \
@@ -1362,6 +1400,9 @@ tuya_sync_deps() {
     tuya_stage sync
     local plan saved_index="" saved_url="" rc=0 pkg_count
     tuya_uv_reset_diag
+    if command -v pgrep >/dev/null 2>&1 && pgrep -x uv >/dev/null 2>&1; then
+        tuya_warn_uv_lock_contention 'Another uv process is already running; dependency sync may pause until it finishes.'
+    fi
     plan=$(tuya_uv_sync_plan)
     pkg_count=$(tuya_lock_pkg_count)
     local src='PyPI (default)'
@@ -1390,6 +1431,11 @@ tuya_sync_deps() {
     esac
     [ "$rc" -ne 0 ] && tuya_sync_deps_error
     return "$rc"
+}
+
+tuya_file_mtime_epoch() {
+    # File mtime as epoch seconds: GNU stat (Linux), then BSD stat (macOS).
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
 }
 
 tuya_is_uv_venv() {
@@ -1424,8 +1470,9 @@ tuya_migrate_legacy_venv() {
 
 tuya_setup_venv() {
     tuya_stage venv
-    local managed_python="${_tuya_managed_python:-}" venv_path="$OPEN_SDK_ROOT/.venv" marker="" rc=0
-    local venv_py="$venv_path/bin/python"
+    local managed_python="${_tuya_managed_python:-}" venv_path="$OPEN_SDK_ROOT/.venv" rc=0
+    local venv_py="$venv_path/bin/python" marker="$venv_path/$TUYA_VENV_MARKER"
+    local created_venv=0 need_sync=1 lock_mtime='' marker_mtime=''
     tuya_migrate_legacy_venv || return 1
 
     if ! tuya_is_uv_venv "$venv_path" || [ ! -x "$venv_py" ]; then
@@ -1439,24 +1486,43 @@ tuya_setup_venv() {
                 'Re-run: . ./export.sh'
             return 1
         }
-        marker="$venv_path/$TUYA_VENV_MARKER"
         printf 'managed-by=export.sh\npython=%s\n' "$TUYA_PYTHON_VERSION" > "$marker" || {
             tuya_error Venv 'Cannot write venv marker.' "$marker" \
                 'Check .venv permissions' 'Re-run: . ./export.sh'
             return 1
         }
+        created_venv=1
         tuya_debug '[TuyaOpen] .venv created.'
     fi
 
-    (
-        cd "$OPEN_SDK_ROOT" || exit 1
-        tuya_sync_deps
-    ) || rc=$?
-    if [ "$rc" -ne 0 ]; then
-        # tuya_sync_deps already reported the specific cause (incl. uv output).
-        return 1
+    # Warm start: skip sync when uv.lock has not changed since the last
+    # successful sync (the marker mtime is refreshed after each sync). This
+    # keeps re-sourcing fast and avoids re-acquiring the venv lock every time.
+    # TUYAOPEN_EXPORT_VERBOSE forces a full sync (self-repair escape hatch).
+    if [ "$created_venv" -eq 0 ] && [ -z "${TUYAOPEN_EXPORT_VERBOSE:-}" ]; then
+        lock_mtime=$(tuya_file_mtime_epoch "$OPEN_SDK_ROOT/uv.lock") || lock_mtime=''
+        marker_mtime=$(tuya_file_mtime_epoch "$marker") || marker_mtime=''
+        if [ -n "$lock_mtime" ] && [ -n "$marker_mtime" ] && [ "$lock_mtime" -le "$marker_mtime" ]; then
+            need_sync=0
+        fi
     fi
-    tuya_debug '[TuyaOpen] Dependencies synced.'
+
+    if [ "$need_sync" -eq 1 ]; then
+        (
+            cd "$OPEN_SDK_ROOT" || exit 1
+            tuya_sync_deps
+        ) || rc=$?
+        if [ "$rc" -ne 0 ]; then
+            # tuya_sync_deps already reported the specific cause (incl. uv output).
+            return 1
+        fi
+        tuya_debug '[TuyaOpen] Dependencies synced.'
+        # Record the sync time so an unchanged uv.lock can skip sync next source.
+        touch "$marker" 2>/dev/null || true
+    else
+        tuya_stage sync
+        tuya_info '[TuyaOpen] Python dependencies up to date (uv.lock unchanged); skipping sync.'
+    fi
 
     if [ ! -x "$venv_py" ]; then
         tuya_error Sync '.venv Python missing after sync.' "$venv_py" \


### PR DESCRIPTION
### PR 描述/PR description

替代 #633（已关闭），彻底修复 uv 环境锁导致的 sync 卡死问题。/ Replaces #633 (closed); a complete fix for syncs hanging on the uv environment lock.

**问题定性 / Root cause analysis**（在 Windows 上用持锁进程实测验证 / verified experimentally on Windows with a live lock holder）:

1. uv 等待被占用的 `.venv/.lock` 时**完全静默**（不加 `-v` 无任何输出），用户看到的就是 export 卡死。/ uv waits for a busy `.venv/.lock` **silently** (no output without `-v`), so a blocked sync looks like a hang.
2. 最常见的持锁者是孤儿 uv 进程：`export.sh` 以后台任务方式运行 uv，Ctrl+C 到不了它，它继续持锁。/ The most common holder is an orphaned uv: `export.sh` runs uv as a background job, Ctrl+C never reaches it, and it keeps the lock.
3. **成功安装后 `.venv/.lock` 文件也会正常残留**（0 字节、无 PID），文件本身无害——这正是 #633 的问题：基于 mtime/PID 启发式对残留文件告警，会在每次热启动误报；且它 sync 后不刷新 marker 时间戳，git pull 之后会永远重复 sync。/ A leftover `.venv/.lock` **file is normal after every successful run** (0 bytes, no PID) and harmless — which is why #633 was wrong: its mtime/PID heuristics would false-positive on every warm start, and it never refreshed the marker after sync, so its skip logic re-synced forever after a git pull.

**修复内容 / Changes**:

- `export.sh`：`tuya_uv_run_stream` 在 INT/TERM 时杀掉后台 uv 子进程（根因修复；`trap -p` 可用时恢复用户原有 trap）。/ kill the background uv child on INT/TERM (root cause; prior user traps restored where `trap -p` is available).
- 两个脚本：sync/流式运行 10 秒无任何输出时告警一次，解释锁等待及排查方法（ps1 用 OnPoll 看门狗；sh 用一次性后台看门狗 + 哨兵文件，兼容 bash/zsh/POSIX）。/ both scripts: warn once after 10+ seconds of total silence, explaining the lock wait and how to resolve it (ps1: OnPoll watchdog; sh: one-shot background watchdog + sentinel, bash/zsh/POSIX safe).
- 两个脚本：sync 开始前若检测到已有 uv 进程在运行，提前提示可能等锁。/ both: up-front hint when another uv process is already running.
- 两个脚本：热启动时 `uv.lock` 不比 venv marker 新则跳过 sync，且每次成功 sync 后刷新 marker 时间戳（修正 #633 缺失的一环）；`TUYAOPEN_EXPORT_VERBOSE=1` 强制完整 sync 作为自修复出口。/ both: skip sync on warm starts when `uv.lock` is not newer than the venv marker, refreshing the marker mtime after each successful sync (the piece #633 missed); `TUYAOPEN_EXPORT_VERBOSE=1` forces a full sync as the self-repair escape hatch.
- `export.ps1`：already-active 守卫命中时补注册 `tos.py` / `deactivate` 函数——环境变量会被子进程继承而函数不会，此前继承了变量的新终端会陷入"无法 deactivate 也无法重新激活"的死锁。/ re-register `tos.py` / `deactivate` on the already-active guard path — env vars are inherited by child processes but functions are session-local, so a shell that inherited the vars was previously stuck (cannot deactivate, cannot re-activate).

**测试 / Testing**（Windows 11, PowerShell 7 + Git Bash）:

- ps1：持有 `.venv/.lock` 字节区间锁（LockFileEx，与 uv 同机制）时运行 mutating sync → 10 秒出现看门狗提示，锁释放后 sync 正常完成、包恢复、marker 刷新；随后热启动正确跳过 sync。
- sh：假 uv 三种情况（立即退出/静默 12 秒/退出码 3）→ 无误报、10 秒告警、退出码正确传播；对 sourcing shell 发 TERM → 后台 uv 被正确杀死（rc=143），不再产生持锁孤儿。
- 两个文件均通过语法检查（`bash -n` / PowerShell Parser）。

### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I have considered the following:
- [x] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循文件头格式。(N/A - shell/PowerShell scripts)
- [ ] 确保函数头遵循 Doxygen 格式。(N/A - shell/PowerShell scripts)
- [x] 已查阅编码风格指南，并核查代码风格合规性。Reviewed the coding style guide and verified style compliance with the surrounding script code.
- [ ] 已使用代码格式化工具。(N/A - C formatter does not apply)