### PR TITLE
feat(cli): switch tyutool download to release.json manifest

### DIFF
--- a/tools/cli_command/cli_update.py
+++ b/tools/cli_command/cli_update.py
@@ -9,7 +9,7 @@ from tools.cli_command.util import (
     get_logger, get_global_params, parse_yaml
 )
 from tools.cli_command.util_git import git_checkout
-from tools.cli_command.util_tyutool import fetch_latest_json, download_tyutool_bin
+from tools.cli_command.util_tyutool import fetch_release_json, download_tyutool_bin
 
 
 def update_tyutool(force):
@@ -24,12 +24,12 @@ def update_tyutool(force):
         logger.debug("tyutool not installed, skipping.")
         return True
 
-    latest_data = fetch_latest_json()
-    if not latest_data:
+    release_data = fetch_release_json()
+    if not release_data:
         logger.error("Failed to get latest tyutool version.")
         return False
 
-    ret = download_tyutool_bin(latest_data)
+    ret = download_tyutool_bin(release_data)
     if ret:
         from tools.cli_command.util import env_write
         env_write("tyutool_last_check", time.time())

--- a/tools/cli_command/tests/test_util_tyutool.py
+++ b/tools/cli_command/tests/test_util_tyutool.py
@@ -105,10 +105,10 @@ class TestShouldCheckUpdate(unittest.TestCase):
             self.assertFalse(self.fn())
 
 
-class TestFetchLatestJson(unittest.TestCase):
+class TestFetchReleaseJson(unittest.TestCase):
     def setUp(self):
         import tools.cli_command.util_tyutool as m
-        self.fn = m.fetch_latest_json
+        self.fn = m.fetch_release_json
 
     def test_success_returns_dict(self):
         fake_json = {"version": "3.0.7", "cli": {}}
@@ -333,7 +333,7 @@ class TestEnsureTyutool(unittest.TestCase):
         }
 
     def test_fetch_failure_updates_last_check(self):
-        """Bug fix: when fetch_latest_json fails, tyutool_last_check must still be updated
+        """Bug fix: when fetch_release_json fails, tyutool_last_check must still be updated
         to prevent repeated network requests on every subsequent invocation."""
         import tools.cli_command.util_tyutool as m
         with tempfile.TemporaryDirectory() as tmp:
@@ -343,12 +343,12 @@ class TestEnsureTyutool(unittest.TestCase):
             written = {}
             with patch('tools.cli_command.util_tyutool.get_global_params', return_value=params), \
                  patch('tools.cli_command.util_tyutool.should_check_update', return_value=True), \
-                 patch('tools.cli_command.util_tyutool.fetch_latest_json', return_value=None), \
+                 patch('tools.cli_command.util_tyutool.fetch_release_json', return_value=None), \
                  patch('tools.cli_command.util_tyutool.env_write', side_effect=lambda k, v: written.update({k: v})):
                 result = m.ensure_tyutool()
             self.assertEqual(result, bin_path)
             self.assertIn("tyutool_last_check", written,
-                          "tyutool_last_check must be updated even when fetch_latest_json fails")
+                          "tyutool_last_check must be updated even when fetch_release_json fails")
 
     def test_binary_version_takes_priority_over_env(self):
         """Always detect version from binary so stale env cache can't cause false update prompts."""
@@ -360,7 +360,7 @@ class TestEnsureTyutool(unittest.TestCase):
             prompted = []
             with patch('tools.cli_command.util_tyutool.get_global_params', return_value=params), \
                  patch('tools.cli_command.util_tyutool.should_check_update', return_value=True), \
-                 patch('tools.cli_command.util_tyutool.fetch_latest_json',
+                 patch('tools.cli_command.util_tyutool.fetch_release_json',
                        return_value={"version": "3.0.10"}), \
                  patch('tools.cli_command.util_tyutool._detect_installed_version',
                        return_value="3.0.10"), \

--- a/tools/cli_command/tests/test_util_tyutool.py
+++ b/tools/cli_command/tests/test_util_tyutool.py
@@ -140,6 +140,23 @@ class TestFetchLatestJson(unittest.TestCase):
             result = self.fn()
         self.assertIsNone(result)
 
+    def test_fetches_release_json(self):
+        import tools.cli_command.util_tyutool as m
+        tried_urls = []
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.json.return_value = {"version": "3.2.7"}
+        mock_resp.raise_for_status.return_value = None
+
+        def fake_get(url, **kwargs):
+            tried_urls.append(url)
+            return mock_resp
+
+        with patch('tools.cli_command.util_tyutool.requests.get',
+                   side_effect=fake_get):
+            result = self.fn()
+        self.assertEqual(result, {"version": "3.2.7"})
+        self.assertEqual(tried_urls, [m.RELEASE_JSON_URL])
+
 
 class TestGetLocalVersion(unittest.TestCase):
     def setUp(self):
@@ -158,11 +175,13 @@ class TestGetLocalVersion(unittest.TestCase):
 
 
 class TestDownloadTyutoolBin(unittest.TestCase):
-    FAKE_LATEST = {
-        "version": "3.0.7",
+    FAKE_RELEASE = {
+        "version": "3.2.7",
         "cli": {
             "linux-x86_64": {
-                "url": "https://github.com/tuya/tyutool/releases/download/v3.0.7/tyutool-cli_linux_x86_64_3.0.7.tar.gz",
+                "url": "https://airtake-public-data.example.com/tyutool/v3.2.7/tyutool-cli_linux_x86_64_3.2.7.tar.gz",
+                "url_github": "https://github.com/tuya/tyutool/releases/download/v3.2.7/tyutool-cli_linux_x86_64_3.2.7.tar.gz",
+                "url_tuya": "https://airtake-public-data.example.com/tyutool/v3.2.7/tyutool-cli_linux_x86_64_3.2.7.tar.gz",
                 "sha256": "FAKE_SHA256",
             }
         }
@@ -203,7 +222,7 @@ class TestDownloadTyutoolBin(unittest.TestCase):
                  patch('tools.cli_command.util_tyutool.env_write'), \
                  patch('tools.cli_command.util_tyutool._download_file',
                        side_effect=fake_download):
-                result = m.download_tyutool_bin(self.FAKE_LATEST)
+                result = m.download_tyutool_bin(self.FAKE_RELEASE)
         self.assertFalse(result)
 
     def test_all_sources_fail_returns_false(self):
@@ -218,10 +237,10 @@ class TestDownloadTyutoolBin(unittest.TestCase):
                        return_value="US"), \
                  patch('tools.cli_command.util_tyutool._download_file',
                        return_value=False):
-                result = m.download_tyutool_bin(self.FAKE_LATEST)
+                result = m.download_tyutool_bin(self.FAKE_RELEASE)
         self.assertFalse(result)
 
-    def test_gitee_prioritized_for_china(self):
+    def _tried_urls(self, country):
         import tools.cli_command.util_tyutool as m
         with tempfile.TemporaryDirectory() as tmp:
             params = self._make_params(tmp)
@@ -234,12 +253,23 @@ class TestDownloadTyutoolBin(unittest.TestCase):
                  patch('tools.cli_command.util_tyutool.get_platform_key',
                        return_value="linux-x86_64"), \
                  patch('tools.cli_command.util_tyutool.get_country_code',
-                       return_value="China"), \
+                       return_value=country), \
                  patch('tools.cli_command.util_tyutool._download_file',
                        side_effect=fake_download):
-                m.download_tyutool_bin(self.FAKE_LATEST)
-        self.assertIn("gitee.com", tried_urls[0])
-        self.assertIn("github.com", tried_urls[1])
+                m.download_tyutool_bin(self.FAKE_RELEASE)
+        return tried_urls
+
+    def test_url_tuya_prioritized_for_china(self):
+        tried_urls = self._tried_urls("China")
+        cli_info = self.FAKE_RELEASE["cli"]["linux-x86_64"]
+        self.assertEqual(
+            tried_urls, [cli_info["url_tuya"], cli_info["url_github"]])
+
+    def test_url_github_prioritized_overseas(self):
+        tried_urls = self._tried_urls("US")
+        cli_info = self.FAKE_RELEASE["cli"]["linux-x86_64"]
+        self.assertEqual(
+            tried_urls, [cli_info["url_github"], cli_info["url_tuya"]])
 
     def test_successful_install(self):
         import io, hashlib, tarfile as _tarfile
@@ -282,6 +312,7 @@ class TestDownloadTyutoolBin(unittest.TestCase):
                        return_value="linux-x86_64"), \
                  patch('tools.cli_command.util_tyutool.get_country_code',
                        return_value="US"), \
+                 patch('tools.cli_command.util_tyutool.sys.platform', 'linux'), \
                  patch('tools.cli_command.util_tyutool._download_file',
                        side_effect=fake_download), \
                  patch('tools.cli_command.util_tyutool.env_write',

--- a/tools/cli_command/util_tyutool.py
+++ b/tools/cli_command/util_tyutool.py
@@ -68,14 +68,14 @@ def should_check_update() -> bool:
     return (time.time() - float(last_check)) >= CHECK_INTERVAL
 
 
-def fetch_latest_json() -> Optional[dict]:
+def fetch_release_json() -> Optional[dict]:
     logger = get_logger()
     try:
         resp = requests.get(RELEASE_JSON_URL, timeout=10)
         resp.raise_for_status()
         return resp.json()
     except Exception as e:
-        logger.debug(f"fetch_latest_json failed: {e}")
+        logger.debug(f"fetch_release_json failed: {e}")
         return None
 
 
@@ -194,14 +194,14 @@ def _sha256_file(path: str) -> str:
     return h.hexdigest()
 
 
-def download_tyutool_bin(latest_data: dict) -> bool:
+def download_tyutool_bin(release_data: dict) -> bool:
     logger = get_logger()
     params = get_global_params()
     tyutool_bin_dir = params["tyutool_bin_dir"]
     tyutool_bin = params["tyutool_bin"]
 
     platform_key = get_platform_key()
-    cli_info = latest_data.get("cli", {}).get(platform_key)
+    cli_info = release_data.get("cli", {}).get(platform_key)
     if not cli_info:
         logger.error(f"No CLI binary available for platform: {platform_key}")
         return False
@@ -211,7 +211,8 @@ def download_tyutool_bin(latest_data: dict) -> bool:
     if not urls:
         logger.error(f"No download URL available for platform: {platform_key}")
         return False
-    asset_name = urls[0].split('/')[-1]
+    # strip any query string so the asset keeps a valid filename/extension
+    asset_name = urls[0].split('?')[0].split('/')[-1]
     bin_name = "tyutool_cli.exe" if sys.platform == "win32" else "tyutool_cli"
 
     tmp_dir = os.path.join(tyutool_bin_dir, ".tmp")
@@ -221,7 +222,7 @@ def download_tyutool_bin(latest_data: dict) -> bool:
 
     try:
         logger.info(
-            f"Downloading tyutool {latest_data['version']} for {platform_key} ..."
+            f"Downloading tyutool {release_data['version']} for {platform_key} ..."
         )
         downloaded = False
         for url in urls:
@@ -268,8 +269,8 @@ def download_tyutool_bin(latest_data: dict) -> bool:
 
         os.makedirs(tyutool_bin_dir, exist_ok=True)
         shutil.move(extracted_bin, tyutool_bin)
-        env_write("tyutool_version", latest_data["version"])
-        logger.info(f"tyutool {latest_data['version']} installed successfully.")
+        env_write("tyutool_version", release_data["version"])
+        logger.info(f"tyutool {release_data['version']} installed successfully.")
         return True
 
     finally:
@@ -279,7 +280,7 @@ def download_tyutool_bin(latest_data: dict) -> bool:
             shutil.rmtree(extract_dir)
 
 
-def prompt_update(local_ver: str, latest_ver: str, latest_data: dict) -> bool:
+def prompt_update(local_ver: str, latest_ver: str, release_data: dict) -> bool:
     logger = get_logger()
     if not sys.stdin.isatty():
         logger.info(
@@ -297,7 +298,7 @@ def prompt_update(local_ver: str, latest_ver: str, latest_data: dict) -> bool:
         except (EOFError, KeyboardInterrupt):
             return True
         if ret == "Y":
-            if not download_tyutool_bin(latest_data):
+            if not download_tyutool_bin(release_data):
                 logger.warning("Update failed, continuing with current version.")
             return True
         elif ret == "N":
@@ -320,13 +321,13 @@ def ensure_tyutool() -> Optional[str]:
             logger.debug(f"Failed to remove old tyutool: {e}")
 
     if not os.path.isfile(tyutool_bin):
-        latest_data = fetch_latest_json()
-        if not latest_data:
+        release_data = fetch_release_json()
+        if not release_data:
             logger.error(
                 "Cannot fetch tyutool version info. Please check your network."
             )
             return None
-        if not download_tyutool_bin(latest_data):
+        if not download_tyutool_bin(release_data):
             return None
         env_write("tyutool_last_check", time.time())
         return tyutool_bin
@@ -334,15 +335,15 @@ def ensure_tyutool() -> Optional[str]:
     if not should_check_update():
         return tyutool_bin
 
-    latest_data = fetch_latest_json()
-    if latest_data is None:
+    release_data = fetch_release_json()
+    if release_data is None:
         env_write("tyutool_last_check", time.time())
         return tyutool_bin
 
-    latest_ver = latest_data.get("version", "")
+    latest_ver = release_data.get("version", "")
     local_ver = _detect_installed_version(tyutool_bin) or get_local_version() or ""
     if compare_versions(latest_ver, local_ver) > 0:
-        prompt_update(local_ver, latest_ver, latest_data)
+        prompt_update(local_ver, latest_ver, release_data)
 
     env_write("tyutool_last_check", time.time())
     return tyutool_bin

--- a/tools/cli_command/util_tyutool.py
+++ b/tools/cli_command/util_tyutool.py
@@ -20,11 +20,9 @@ from tools.cli_command.util import (
 )
 
 CHECK_INTERVAL = 86400  # 24 hours
-LATEST_JSON_URL = (
-    "https://github.com/tuya/tyutool/releases/latest/download/latest.json"
+RELEASE_JSON_URL = (
+    "https://github.com/tuya/tyutool/releases/latest/download/release.json"
 )
-_GITHUB_PREFIX = "https://github.com/tuya/tyutool"
-_GITEE_PREFIX = "https://gitee.com/tuya-open/tyutool"
 
 
 def get_platform_key() -> str:
@@ -73,7 +71,7 @@ def should_check_update() -> bool:
 def fetch_latest_json() -> Optional[dict]:
     logger = get_logger()
     try:
-        resp = requests.get(LATEST_JSON_URL, timeout=10)
+        resp = requests.get(RELEASE_JSON_URL, timeout=10)
         resp.raise_for_status()
         return resp.json()
     except Exception as e:
@@ -100,8 +98,22 @@ def _detect_installed_version(tyutool_bin: str) -> str:
         return ""
 
 
-def _make_gitee_url(github_url: str) -> str:
-    return github_url.replace(_GITHUB_PREFIX, _GITEE_PREFIX)
+def _select_download_urls(cli_info: dict) -> list:
+    """Order download URLs by region.
+
+    release.json entries carry explicit `url_tuya` (mainland China CDN) and
+    `url_github` fields; mainland China prefers `url_tuya`, elsewhere prefers
+    `url_github`, each falling back to the other source.
+    """
+    url_github = cli_info.get("url_github") or cli_info.get("url", "")
+    url_tuya = cli_info.get("url_tuya") or cli_info.get("url", "")
+
+    if "China" in get_country_code():
+        urls = [url_tuya, url_github]
+    else:
+        urls = [url_github, url_tuya]
+    # drop empties and duplicates, keep order
+    return list(dict.fromkeys(u for u in urls if u))
 
 
 DOWNLOAD_TIMEOUT = 300  # 5 minutes total cap for binary download
@@ -194,16 +206,13 @@ def download_tyutool_bin(latest_data: dict) -> bool:
         logger.error(f"No CLI binary available for platform: {platform_key}")
         return False
 
-    github_url = cli_info["url"]
     expected_sha256 = cli_info["sha256"]
-    asset_name = github_url.split('/')[-1]
+    urls = _select_download_urls(cli_info)
+    if not urls:
+        logger.error(f"No download URL available for platform: {platform_key}")
+        return False
+    asset_name = urls[0].split('/')[-1]
     bin_name = "tyutool_cli.exe" if sys.platform == "win32" else "tyutool_cli"
-
-    gitee_url = _make_gitee_url(github_url)
-    if "China" in get_country_code():
-        urls = [gitee_url, github_url]
-    else:
-        urls = [github_url, gitee_url]
 
     tmp_dir = os.path.join(tyutool_bin_dir, ".tmp")
     extract_dir = os.path.join(tyutool_bin_dir, ".tmp_extract")


### PR DESCRIPTION
## Summary

- Fetch tyutool version info from `release.json` (the new manifest published on the latest tyutool release) instead of `latest.json`
- Pick download sources from the manifest's explicit per-entry fields: `url_tuya` is preferred in mainland China, `url_github` elsewhere, each falling back to the other; the old GitHub→Gitee URL rewriting is removed
- Rename `fetch_latest_json`/`latest_data` to `fetch_release_json`/`release_data` to match the manifest, and strip query strings when deriving the asset filename so signed CDN URLs cannot produce invalid filenames or break archive-extension detection

## Tests

- Updated unit tests to the release.json entry format; added cases for manifest URL, China/overseas source ordering
- Fixed `test_successful_install`, which previously failed on Windows because the fake archive used the non-Windows binary name
- Full suite: `python -m unittest discover -s tools/cli_command/tests` — 57 tests, all passing
- Smoke-tested against the live manifest: fetched v3.2.7 and verified region-ordered URLs