### PR TITLE
fix: detect and self-repair broken venv build tools (cmake/ninja) on Windows

### DIFF
--- a/export.ps1
+++ b/export.ps1
@@ -1828,6 +1828,7 @@ function Invoke-TuyaSetupVenv {
     $venvPath = Join-Path $Root '.venv'
     $venvPy   = Join-Path $venvPath 'Scripts\python.exe'
     $marker   = Get-TuyaVenvMarkerPath -VenvPath $venvPath
+    $syncStamp = Join-Path $venvPath '.uv-sync-ok'
     $createdVenv = $false
 
     if (-not (Test-TuyaUvManagedVenv -VenvPath $venvPath) -or -not (Test-Path -LiteralPath $venvPy -PathType Leaf)) {
@@ -1849,17 +1850,20 @@ function Invoke-TuyaSetupVenv {
         Write-TuyaOpenDebug '[TuyaOpen] .venv created.'
     }
 
-    # Warm start: skip sync when uv.lock has not changed since the last
-    # successful sync (the marker mtime is refreshed after each sync). This
-    # keeps re-sourcing fast and avoids re-acquiring the venv lock every time.
+    # Warm start: skip sync only when a PREVIOUS sync SUCCEEDED (the .uv-sync-ok
+    # stamp is written only after uv sync returns 0) and uv.lock has not changed
+    # since. The stamp is deliberately separate from the venv marker: the marker
+    # is written when the venv is first created (before sync), so keying the skip
+    # on it would make a failed/interrupted first sync permanently skip sync on
+    # every later run, leaving dependencies (e.g. cmake) half-installed.
     # TUYAOPEN_EXPORT_VERBOSE=1 forces a full sync (self-repair escape hatch).
     $needSync = $true
     if (-not $createdVenv -and -not $script:TuyaOpenVerbose) {
         $lockStamp = $null
-        $markerStamp = $null
-        try { $lockStamp   = (Get-Item -LiteralPath (Join-Path $Root 'uv.lock') -ErrorAction Stop).LastWriteTimeUtc } catch {}
-        try { $markerStamp = (Get-Item -LiteralPath $marker -ErrorAction Stop).LastWriteTimeUtc } catch {}
-        if ($null -ne $lockStamp -and $null -ne $markerStamp -and $lockStamp -le $markerStamp) {
+        $syncStampTime = $null
+        try { $lockStamp     = (Get-Item -LiteralPath (Join-Path $Root 'uv.lock') -ErrorAction Stop).LastWriteTimeUtc } catch {}
+        try { $syncStampTime = (Get-Item -LiteralPath $syncStamp -ErrorAction Stop).LastWriteTimeUtc } catch {}
+        if ($null -ne $lockStamp -and $null -ne $syncStampTime -and $lockStamp -le $syncStampTime) {
             $needSync = $false
         }
     }
@@ -1884,7 +1888,9 @@ function Invoke-TuyaSetupVenv {
             }
             Write-TuyaOpenDebug '[TuyaOpen] Dependencies synced.'
         } finally { Pop-Location }
-        try { (Get-Item -LiteralPath $marker -ErrorAction Stop).LastWriteTimeUtc = [datetime]::UtcNow } catch {}
+        # Mark sync success (only reached when syncRc -eq 0). Writing the file
+        # sets its mtime to now, which the warm-start check above compares to uv.lock.
+        Write-TuyaMarkerFile -Path $syncStamp -Content ("synced=" + ([datetime]::UtcNow.ToString('o'))) | Out-Null
     } else {
         Write-TuyaOpenStage -StageId 'sync'
         Write-TuyaOpenInfo '[TuyaOpen] Python dependencies up to date (uv.lock unchanged); skipping sync.'

--- a/export.sh
+++ b/export.sh
@@ -1472,7 +1472,8 @@ tuya_setup_venv() {
     tuya_stage venv
     local managed_python="${_tuya_managed_python:-}" venv_path="$OPEN_SDK_ROOT/.venv" rc=0
     local venv_py="$venv_path/bin/python" marker="$venv_path/$TUYA_VENV_MARKER"
-    local created_venv=0 need_sync=1 lock_mtime='' marker_mtime=''
+    local sync_stamp="$venv_path/.uv-sync-ok"
+    local created_venv=0 need_sync=1 lock_mtime='' sync_mtime=''
     tuya_migrate_legacy_venv || return 1
 
     if ! tuya_is_uv_venv "$venv_path" || [ ! -x "$venv_py" ]; then
@@ -1495,14 +1496,17 @@ tuya_setup_venv() {
         tuya_debug '[TuyaOpen] .venv created.'
     fi
 
-    # Warm start: skip sync when uv.lock has not changed since the last
-    # successful sync (the marker mtime is refreshed after each sync). This
-    # keeps re-sourcing fast and avoids re-acquiring the venv lock every time.
+    # Warm start: skip sync only when a PREVIOUS sync SUCCEEDED (.uv-sync-ok is
+    # written only after uv sync returns 0) and uv.lock has not changed since.
+    # The stamp is deliberately separate from the venv marker: the marker is
+    # written when the venv is first created (before sync), so keying the skip on
+    # it would make a failed/interrupted first sync permanently skip sync on every
+    # later run, leaving dependencies (e.g. cmake) half-installed.
     # TUYAOPEN_EXPORT_VERBOSE forces a full sync (self-repair escape hatch).
     if [ "$created_venv" -eq 0 ] && [ -z "${TUYAOPEN_EXPORT_VERBOSE:-}" ]; then
         lock_mtime=$(tuya_file_mtime_epoch "$OPEN_SDK_ROOT/uv.lock") || lock_mtime=''
-        marker_mtime=$(tuya_file_mtime_epoch "$marker") || marker_mtime=''
-        if [ -n "$lock_mtime" ] && [ -n "$marker_mtime" ] && [ "$lock_mtime" -le "$marker_mtime" ]; then
+        sync_mtime=$(tuya_file_mtime_epoch "$sync_stamp") || sync_mtime=''
+        if [ -n "$lock_mtime" ] && [ -n "$sync_mtime" ] && [ "$lock_mtime" -le "$sync_mtime" ]; then
             need_sync=0
         fi
     fi
@@ -1517,8 +1521,9 @@ tuya_setup_venv() {
             return 1
         fi
         tuya_debug '[TuyaOpen] Dependencies synced.'
-        # Record the sync time so an unchanged uv.lock can skip sync next source.
-        touch "$marker" 2>/dev/null || true
+        # Record sync success (only reached when tuya_sync_deps returned 0); the
+        # warm-start check above compares this stamp's mtime to uv.lock.
+        touch "$sync_stamp" 2>/dev/null || true
     else
         tuya_stage sync
         tuya_info '[TuyaOpen] Python dependencies up to date (uv.lock unchanged); skipping sync.'

--- a/tools/cli_command/cli_build.py
+++ b/tools/cli_command/cli_build.py
@@ -330,6 +330,15 @@ def build_project(verbose=False, log_file=None, log_file_append=False):
         logger = get_logger()
         check_proj_dir()
 
+        # export.{sh,ps1,bat} is always the entry point and already prepares
+        # cmake/ninja; re-verify here so a toolchain broken AFTER export (e.g.
+        # antivirus removed cmake, or an interrupted sync) fails fast with a
+        # clear, self-healing message instead of a cryptic cmake error later.
+        from tools.cli_command.cli_prepare import ensure_build_tools
+        if not ensure_build_tools():
+            logger.error("Build tools (cmake/ninja) are missing or broken.")
+            return False
+
         if not env_check():
             logger.error("Env check error.")
             return False

--- a/tools/cli_command/cli_check.py
+++ b/tools/cli_command/cli_check.py
@@ -58,8 +58,10 @@ def _compare_version(actual: str, required: str) -> bool:
     return True
 
 
-def check_command_version(tool_name, min_version, ver_cmd="--version"):
+def check_command_version(tool_name, min_version, ver_cmd="--version",
+                          label=None):
     logger = get_logger()
+    disp = label or tool_name
     cmd = [tool_name, ver_cmd]
     try:
         result = subprocess.run(
@@ -71,15 +73,15 @@ def check_command_version(tool_name, min_version, ver_cmd="--version"):
         )
         cmd_out = result.stdout + result.stderr
     except (subprocess.CalledProcessError, FileNotFoundError):
-        logger.error(f"[{tool_name}] not found, please install.")
+        logger.error(f"[{disp}] not found, please install.")
         return False
 
     tool_ver = _find_version_string(cmd_out)
     if tool_ver == "" or _compare_version(tool_ver, min_version) is False:
         logger.warning(
-            f"[{tool_name}] ({tool_ver} < {min_version}) need update.")
+            f"[{disp}] ({tool_ver} < {min_version}) need update.")
         return False
-    logger.note(f"[{tool_name}] ({tool_ver} >= {min_version}) is ok.")
+    logger.note(f"[{disp}] ({tool_ver} >= {min_version}) is ok.")
     return True
 
 
@@ -99,17 +101,32 @@ def _ensure_make_for_check():
 
 
 def check_base_tools():
-    command_list = [
-        ("git", "--version", "2.0.0"),
-        ("cmake", "--version", "3.28.0"),
-        ("make", "--version", "3.0.0"),
-        ("ninja", "--version", "1.6.0"),
-    ]
+    logger = get_logger()
 
-    for command in command_list:
-        if command[0] == "make":
-            _ensure_make_for_check()
-        check_command_version(command[0], command[2], command[1])
+    # git: system dependency.
+    check_command_version("git", "2.0.0", "--version")
+
+    # cmake / ninja: TuyaOpen-managed (installed into the venv). Resolve by
+    # absolute path and repair if the venv copy is missing or broken, so we
+    # never mis-report "please install" for a bundled-but-damaged tool, and
+    # never silently fall back to a system cmake of an unpinned version.
+    from tools.cli_command.cli_prepare import ensure_venv_tool
+    for pkg, binary, min_ver in (("cmake", "cmake", "3.28.0"),
+                                 ("ninja", "ninja", "1.6.0")):
+        ok, exe = ensure_venv_tool(pkg, binary)
+        if ok and exe:
+            check_command_version(exe, min_ver, "--version", label=binary)
+        else:
+            logger.error(
+                f"[{binary}] TuyaOpen-managed dependency is missing or broken. "
+                f"Re-initialize the environment (. .\\export.ps1 / . ./export.sh) "
+                f"or run: uv sync --reinstall-package {pkg}. "
+                f"If it was removed by antivirus, add .venv to the allowlist."
+            )
+
+    # make: on Windows this is a downloaded .tools/make; keep the self-heal.
+    _ensure_make_for_check()
+    check_command_version("make", "3.0.0", "--version")
 
     copy_pre_commit()
     pass

--- a/tools/cli_command/cli_prepare.py
+++ b/tools/cli_command/cli_prepare.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional, Tuple
 import click
 
 from tools.cli_command.util import (
-    get_logger, get_global_params, env_write,
+    get_logger, get_global_params, env_write, get_country_code,
 )
 from tools.cli_command.util_tyutool import _download_file
 
@@ -232,8 +232,89 @@ def download_host_tools() -> bool:
     return True
 
 
+def _tool_runs_ok(exe: str) -> bool:
+    """Run ``<exe> --version``; True only if it launches and exits 0.
+
+    List form + shell=False keeps paths with spaces / non-ASCII / special
+    characters safe. A present-but-broken tool (e.g. a venv launcher whose
+    payload was removed by antivirus, or an incomplete install) exits non-zero
+    and is thus reported as broken, not merely "missing".
+    """
+    try:
+        subprocess.run(
+            [exe, "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return False
+
+
+def resolve_venv_tool(binary: str) -> Optional[str]:
+    """Absolute path to a venv-provided tool (cmake/ninja), or None.
+
+    Resolved from the running interpreter's Scripts/bin dir (so it does not
+    depend on the caller's PATH being activated). ``shutil.which`` applies
+    PATHEXT, so it returns the real ``.exe`` on Windows.
+    """
+    scripts = os.path.dirname(os.path.abspath(sys.executable))
+    return shutil.which(binary, path=scripts)
+
+
+def ensure_venv_tool(pkg: str, binary: str) -> Tuple[bool, Optional[str]]:
+    """Ensure a venv-managed tool exists and actually runs; repair if not.
+
+    Returns ``(ok, exe)``. When the tool is missing or broken, reinstall just
+    that package via uv. ``--reinstall-package`` is required because uv treats
+    an intact dist-info as "already installed" and would otherwise not restore
+    files that were deleted after install. Needs OPEN_SDK_UV and a .venv.
+    """
+    logger = get_logger()
+    exe = resolve_venv_tool(binary)
+    if exe and _tool_runs_ok(exe):
+        return True, exe
+
+    uv = os.environ.get("OPEN_SDK_UV") or shutil.which("uv")
+    open_root = get_global_params().get("open_root")
+    if uv and open_root and os.path.isdir(os.path.join(open_root, ".venv")):
+        logger.warning(
+            f"[{binary}] dependency missing or broken; reinstalling {pkg} ...")
+        cmd = [uv, "sync", "--frozen", "--reinstall-package", pkg]
+        if get_country_code() == "China":
+            cmd += ["--default-index",
+                    "https://mirrors.aliyun.com/pypi/simple/"]
+        try:
+            subprocess.run(cmd, cwd=open_root)
+        except OSError as e:
+            logger.error(f"[{binary}] reinstall failed to start: {e}")
+        exe = resolve_venv_tool(binary)
+        if exe and _tool_runs_ok(exe):
+            logger.note(f"[{binary}] repaired.")
+            return True, exe
+
+    return False, exe
+
+
+def ensure_build_tools() -> bool:
+    """Verify (and repair) the venv-managed build tools: cmake + ninja."""
+    logger = get_logger()
+    ok = True
+    for pkg, binary in (("cmake", "cmake"), ("ninja", "ninja")):
+        good, _ = ensure_venv_tool(pkg, binary)
+        if not good:
+            logger.error(
+                f"[{binary}] could not be prepared. Re-run export, "
+                f"or: uv sync --reinstall-package {pkg}"
+            )
+            ok = False
+    return ok
+
+
 PREPARE_STEPS: List[Tuple[str, PrepareStep]] = [
     ("download_host_tools", download_host_tools),
+    ("ensure_build_tools", ensure_build_tools),
 ]
 
 


### PR DESCRIPTION
## Problem

On Windows, `tos.py check` reports `[cmake] not found, please install.` even though cmake is a venv-managed dependency (`cmake==4.0.2`) and `git`/`make`/`ninja` all pass. Installing a system cmake does not help.

Root cause is **not** a system-cmake conflict, and **not** a PATH problem (export.{sh,ps1,bat} always runs first and activates the environment, and `ninja` — same dir as `cmake` — passes, proving `.venv\Scripts` is on PATH). Two independent issues:

1. **Broken venv tool mis-reported as "not installed"** — when the venv cmake is present-but-broken (launcher intact, bundled binary missing/corrupt after an interrupted `uv sync`, or removed by antivirus), `cmake --version` exits non-zero. The old check used `check=True`, so a non-zero exit was indistinguishable from "not installed", and the broken venv launcher shadowed any working system cmake.
2. **Warm-start skipped sync after a failed sync** — the venv marker (`.tuyaopen-uv`) is written when the venv is created, *before* `uv sync` runs. Warm-start keyed "skip sync" on that marker's mtime, so a failed/interrupted first sync left dependencies half-installed and every later `export` (and the IDE's *Re-initialize*) silently skipped sync, never repairing.

## Changes

- **`fix(cli): detect and self-repair broken venv build tools`**
  - `cli_prepare.py`: `resolve_venv_tool` (absolute path from the venv, via `sys.executable`), `_tool_runs_ok` (actually run `--version`), `ensure_venv_tool` (reinstall the specific package via `uv sync --reinstall-package` — needed because uv treats an intact dist-info as "already installed"), and `ensure_build_tools` registered as a prepare step so export/Re-initialize repairs cmake/ninja.
  - `cli_check.py`: route cmake/ninja through `ensure_venv_tool`, check by absolute path, and emit an honest "managed dependency broken — re-init / reinstall" message instead of "please install". `check_command_version` gains an optional `label`.
  - `cli_build.py`: re-verify build tools up front so a toolchain broken after export fails fast with the same self-healing message.
- **`fix(export): gate warm-start sync-skip on sync success, not venv creation`**
  - Write a separate `.uv-sync-ok` stamp only after `uv sync` returns 0, and base the skip decision on it. Applied to `export.ps1` and `export.sh`. Existing venvs without the stamp trigger one fast local sync on upgrade.

## Verification

- Simulated a broken cmake (launcher present, bundled payload removed) → `check` now reports "broken; reinstalling cmake ... repaired." and restores cmake 4.0.2.
- Broken + no uv available → honest "managed dependency broken" message (no misleading "install cmake").
- Integrated `check_base_tools()` reports git/cmake/ninja/make all ok with friendly labels.
- `py_compile` on changed Python; `bash -n export.sh` passes.

## Notes / follow-ups (out of scope)

- `do_subprocess` uses `os.system` with unquoted path interpolation, so project paths containing spaces / non-ASCII already break `build` — separate, larger hardening.
- Optional: replace the pip `cmake` with a `.tools` download (as `make` is) to be more robust against antivirus / partial installs.
- Optional: early warning for non-ASCII / overly long project root paths.
