### PR TITLE
fix(boards/T5AI): keep TUYA_T5AI_BOARD as default board choice

### DIFF
--- a/boards/T5AI/Kconfig
+++ b/boards/T5AI/Kconfig
@@ -24,6 +24,9 @@ rsource "./OS_SERVICE_Kconfig"
 
 choice
     prompt "Choice a board"
+    # Keep TUYA_T5AI_BOARD as default even if other boards are listed first.
+    # Old configs often only set LCD/camera options and omit BOARD_CHOICE_*.
+    default BOARD_CHOICE_TUYA_T5AI_BOARD
 
     config BOARD_CHOICE_SPARKLEIOT_T5AI_DEV
         bool "SPARKLEIOT_T5AI_DEV"


### PR DESCRIPTION
SPARKLEIOT_T5AI_DEV was inserted as the first choice option, so configs that only set LCD/camera options (without BOARD_CHOICE_*) silently switched to SPARKLEIOT. Restore an explicit default.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]
此前添加了SPARKLEIOT_T5AI_DEV这块Board 会导致选择T5 AI Board 失败，原因是kconfig这里没有配置好。

### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
