### PR TITLE
Feat/cli config non interactive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,23 @@ Standard flow:
 
 ### Non-interactive configuration guidance
 
-- `tos.py config choice` and `tos.py config menu` are interactive TTY flows. Avoid them in non-interactive cloud runs.
-- Prefer editing `app_default.config` directly for deterministic builds.
+- `tos.py config menu` is an interactive TTY flow. Avoid it in non-interactive cloud runs; use `tos.py config set` instead.
+- Read and write individual symbols without a TTY (the `CONFIG_` prefix is optional everywhere):
+
+```bash
+tos.py config get CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN   # print one value
+tos.py config get -a CONFIG_ENABLE_WIFI                       # type, prompt, deps
+tos.py config list -p MBEDTLS                                 # filtered dump
+tos.py config list -j                                         # JSON, for scripts
+tos.py config set CONFIG_ENABLE_LIBLVGL=y CONFIG_XX=8192      # dependency-aware
+tos.py config set -u CONFIG_ENABLE_LIBLVGL                    # revert to default
+tos.py config diff T5AI                                       # vs a saved config
+tos.py config save -n my_board -f                             # no prompt
+```
+
+- `tos.py config choice -c NAME.config` / `-l` are already non-interactive and remain the right way to switch to a whole saved config.
+- Prefer `config set` over hand-editing `app_default.config`. Hand-editing bypasses kconfiglib, so `choice` symbols are not made mutually exclusive, derived symbols (`CONFIG_PLATFORM_CHOICE`, `CONFIG_CHIP_CHOICE`) are not updated, and `.build/cache/using.cmake` plus `.build/include/tuya_kconfig.h` stay stale on a warm build tree (`tools/kconfiglib/CMakeLists.txt` only generates them when absent). `config set` handles all of that.
+- `config set` exits non-zero and writes nothing when any assignment fails, so a batch is all-or-nothing.
 - To avoid prompt blocks from platform commit checks, create:
 
 ```bash
@@ -80,6 +95,17 @@ Expected packages (see `Dockerfile`):
 - For source changes, run the smallest relevant build or check for the touched area.
 - For formatting-only updates, run `tools/check_format.py` against changed files.
 - For docs-only updates, verify file content, command correctness, and path validity.
+- For `tools/cli_command/` changes, run the Python unit tests from the repo root (`-t .` is required so the `tools.cli_command.*` imports resolve):
+
+```bash
+python -m unittest discover -s tools/cli_command/tests -t . -p "test_*.py"
+```
+
+- The `tos.py config` end-to-end tests load the real Kconfig tree and are opt-in (no compilation involved):
+
+```bash
+TUYAOPEN_E2E=1 python -m unittest tools.cli_command.tests.test_config_e2e
+```
 
 ### Artifacts and output locations
 

--- a/tools/cli_command/cli_build.py
+++ b/tools/cli_command/cli_build.py
@@ -134,8 +134,8 @@ def prepare_platform(platform, chip=""):
         parpare_cmd = "./platform_prepare.sh"
 
     logger.info(f"Preparing platform [{platform}] ...")
-    cmd = f"cd {platform_root} && {parpare_cmd} {chip}"
-    ret = do_subprocess(cmd)
+    cmd = f"{parpare_cmd} {chip}"
+    ret = do_subprocess(cmd, cwd=platform_root)
     if 0 != ret:
         return False
     return True
@@ -165,9 +165,9 @@ def build_setup(platform, project_name, framework, chip=""):
         setup_cmd = "./build_setup.sh"
 
     logger.info("Build setup ...")
-    cmd = f"cd {platform_root} && {setup_cmd} "
+    cmd = f"{setup_cmd} "
     cmd += f"{project_name} {platform} {framework} {chip}"
-    ret = do_subprocess(cmd)
+    ret = do_subprocess(cmd, cwd=platform_root)
     if 0 != ret:
         return False
     return True
@@ -227,8 +227,7 @@ def cmake_configure(using_data, verbose=False):
     cmd += " ".join(defines)
 
     build_path = params["app_build_path"]
-    cmake_cmd = f"cd {build_path} && {cmd}"
-    ret = do_subprocess(cmake_cmd)
+    ret = do_subprocess(cmd, cwd=build_path)
     if 0 != ret:
         return False
     return True
@@ -243,8 +242,7 @@ def ninja_build(build_path, verbose=False):
     if verbose:
         cmd += "--verbose "
 
-    ninja_cmd = f"cd {build_path} && {cmd}"
-    ret = do_subprocess(ninja_cmd)
+    ret = do_subprocess(cmd, cwd=build_path)
     if 0 != ret:
         return False
     return True

--- a/tools/cli_command/cli_clean.py
+++ b/tools/cli_command/cli_clean.py
@@ -24,9 +24,8 @@ def clean_project(log_file=None):
             return True
 
         cmd = "ninja clean_all"
-        ninja_cmd = f"cd {build_path} && {cmd}"
 
-        ret = do_subprocess(ninja_cmd)
+        ret = do_subprocess(cmd, cwd=build_path)
         if 0 != ret:
             logger.error("Clean error.")
             return False

--- a/tools/cli_command/cli_config.py
+++ b/tools/cli_command/cli_config.py
@@ -9,10 +9,21 @@
 #   tos.py config choice -l                     # list all available app configs
 #   tos.py config choice -d -l                  # list all board default configs
 #   tos.py config menu                          # open menuconfig UI
-#   tos.py config save                          # save current config to app configs
+#
+#   tos.py config set CONFIG_ENABLE_LIBLVGL=y   # non-interactive set
+#   tos.py config set BOARD_CHOICE_ESP32=y      # CONFIG_ prefix is optional
+#   tos.py config set -u CONFIG_ENABLE_LIBLVGL  # revert to Kconfig default
+#   tos.py config get CONFIG_PLATFORM_CHOICE    # print one value
+#   tos.py config get -a CONFIG_ENABLE_WIFI     # type / prompt / deps
+#   tos.py config list -p MBEDTLS               # filtered dump
+#   tos.py config list -j                       # JSON, for scripts
+#   tos.py config diff t5ai_default             # compare two configs
+#   tos.py config save                          # interactive save
+#   tos.py config save -n my_board -f           # non-interactive save
 
 import os
 import sys
+import json
 import click
 from kconfiglib import Kconfig
 from menuconfig import menuconfig
@@ -26,18 +37,27 @@ from tools.cli_command.util_files import (
 )
 from tools.cli_command.cli_clean import full_clean_project
 from tools.kconfiglib.set_catalog_config import set_catalog_config
+from tools.cli_command import util_kconfig as ukc
 
 
-def _defconfig(config, dconfig=".config", kconfig="Kconfig"):
+# Generated from using.config by tools/kconfiglib/CMakeLists.txt, which
+# guards both with `if(NOT EXISTS ...)`. Changing using.config without
+# removing these leaves the C macros and the component list stale.
+DERIVED_ARTIFACTS = (
+    ("cache", "using.cmake"),
+    ("include", "tuya_kconfig.h"),
+)
+
+
+def _defconfig(config, dconfig=".config", kconfig="Kconfig",
+               save_old=False):
     '''
     minimum config -> .config, with kconfig
     '''
     os.environ['KCONFIG_CONFIG'] = dconfig
     kconf = Kconfig(kconfig, suppress_traceback=True)
     kconf.load_config(config)
-    kconf.write_config()
-    # print(kconf.load_config(config))
-    # print(kconf.write_config())
+    kconf.write_config(dconfig, save_old=save_old)
     pass
 
 
@@ -90,6 +110,103 @@ def get_board_config_dir(board_path):
             ret.append(os.path.join(entry, "config"))
 
     return ret
+
+
+def _invalidate_derived_artifacts():
+    '''
+    Remove the cmake/header files derived from using.config so the next
+    build regenerates them. Returns the paths actually removed.
+
+    os.remove rather than rm_rf: these are single files, and rm_rf
+    shells out to `del /F /Q` on Windows for no benefit here.
+    '''
+    logger = get_logger()
+    params = get_global_params()
+    build_path = params["app_build_path"]
+    removed = []
+    for parts in DERIVED_ARTIFACTS:
+        target = os.path.join(build_path, *parts)
+        if not os.path.exists(target):
+            continue
+        try:
+            os.remove(target)
+            removed.append(target)
+        except OSError as e:
+            logger.warning(f"Cannot remove [{target}]: {e}")
+    return removed
+
+
+def _normalize_save_name(name):
+    '''
+    Validate a config name and append the .config suffix.
+    Returns "" when the name is unusable, so the caller decides how to
+    fail. Path separators and '..' are rejected: this name is joined
+    onto the app config directory.
+    '''
+    if not name or not name.strip():
+        return ""
+    name = name.strip()
+    if "/" in name or "\\" in name or os.sep in name:
+        return ""
+    if ".." in name:
+        return ""
+    if not name.endswith(".config"):
+        name += ".config"
+    return name
+
+
+def _load_current_kconfig():
+    '''
+    Bootstrap the config state if needed, then load the Kconfig tree
+    with the current using.config applied.
+
+    Deliberately does NOT call full_clean_project(): unlike `choice`
+    and `menu`, the read/modify commands must keep the .build tree they
+    are about to read from.
+    '''
+    init_using_config(force=False)
+    params = get_global_params()
+    return ukc.load_kconfig(params["catalog_kconfig"],
+                            params["using_config"])
+
+
+def _list_known_configs():
+    '''
+    Every selectable minimal config: the app's own config dir plus each
+    board's default config dir.
+    '''
+    params = get_global_params()
+    configs = get_files_from_path(".config",
+                                 params["app_configs_path"], 1)
+    board_dirs = get_board_config_dir(params["boards_root"])
+    configs += get_files_from_path(".config", board_dirs, 0)
+    return sorted(configs)
+
+
+def _resolve_config_path(name):
+    '''
+    Resolve a config reference to a path. Accepts a bare name
+    ("t5ai_default"), a file name ("t5ai_default.config") or an
+    existing path. Returns None when nothing matches.
+    '''
+    if os.path.isfile(name):
+        return name
+    wanted = name if name.endswith(".config") else name + ".config"
+    for path in _list_known_configs():
+        if os.path.basename(path) == wanted:
+            return path
+    return None
+
+
+def _expand_min_config(min_config):
+    '''
+    Expand a minimal config into {CONFIG_NAME: value} through the real
+    Kconfig tree. Diffing the minimal files textually would lie: the
+    same effective config has several valid minimal representations.
+    '''
+    params = get_global_params()
+    kconf = ukc.load_kconfig(params["catalog_kconfig"], min_config)
+    return ukc.raw_snapshot(kconf)
 
 
 @click.command(help="Choice config file.")
@@ -175,8 +292,282 @@ def config_menu_exec():
     sys.exit(0)
 
 
+@click.command(help="Set config symbols, non-interactively. "
+                    "The CONFIG_ prefix is optional. Use '--' before "
+                    "a value that starts with '-'.")
+@click.argument('assignments', nargs=-1, metavar='CONFIG_NAME=VALUE...')
+@click.option('-u', '--unset', 'unsets',
+              multiple=True, metavar='NAME',
+              help="Revert a symbol to its Kconfig default. Repeatable.")
+@click.option('--no-save',
+              is_flag=True, default=False,
+              help="Only update using.config; leave app_default.config "
+                   "untouched. The change is lost on the next clean, "
+                   "and a later set/menu will persist it.")
+@click.option('-k', '--keep-build',
+              is_flag=True, default=False,
+              help="Do not invalidate generated build artifacts.")
+def config_set_exec(assignments, unsets, no_save, keep_build):
+    '''
+    1. Apply assignments through kconfiglib (dependency-aware)
+    2. using.config  <- expanded result
+    3. app_default.config <- minimal result (unless --no-save)
+    4. Invalidate the build artifacts derived from using.config
+    '''
+    logger = get_logger()
+
+    if not assignments and not unsets:
+        logger.error("Nothing to do: give CONFIG_NAME=VALUE or -u NAME.")
+        sys.exit(1)
+
+    # Parse everything before touching any state, so a typo in the last
+    # token cannot leave a half-applied config behind.
+    pairs = []
+    bad = False
+    for token in assignments:
+        try:
+            pairs.append(ukc.parse_assignment(token))
+        except ValueError as e:
+            logger.error(str(e))
+            bad = True
+    if bad:
+        sys.exit(1)
+
+    seen = set()
+    for name, _ in pairs:
+        if name in seen:
+            logger.warning(f"CONFIG_{name} given more than once; "
+                           "the last value wins.")
+        seen.add(name)
+
+    params = get_global_params()
+    using_config = params["using_config"]
+    app_default_config = params["app_default_config"]
+
+    kconf = _load_current_kconfig()
+    before = ukc.identity_values(kconf)
+
+    # Unsets first, then assignments: the CLI cannot express an
+    # interleaved order anyway, and this way an explicit value always
+    # wins over an unset of the same symbol.
+    changes, failed = ukc.apply_unsets(kconf, unsets)
+    applied, set_failed = ukc.apply_assignments(kconf, pairs)
+    changes += applied
+    failed += set_failed
+
+    if failed:
+        for name, reason in failed:
+            logger.error(f"{name}: {reason}")
+        logger.note("Run [tos.py config get -a NAME] to inspect a symbol.")
+        sys.exit(1)
+
+    for name, old, new in changes:
+        if old == new:
+            logger.info(f"{name} already {new}")
+        else:
+            logger.note(f"{name}: {old} -> {new}")
+
+    after = ukc.identity_values(kconf)
+    identity_changed = before != after
+    identity_diff = ", ".join(k for k in after
+                              if before.get(k) != after[k])
+
+    # Switching platform/board forces a full clean, and a full clean
+    # rebuilds using.config from app_default.config -- which --no-save
+    # leaves holding the old board. The combination would silently
+    # discard the change, so refuse it before anything is written.
+    if identity_changed and no_save:
+        logger.error(f"Platform/board identity changed ({identity_diff}); "
+                     "--no-save cannot express that, because the full "
+                     "clean it requires would discard the change.")
+        logger.note("Drop --no-save, or use [tos.py config choice].")
+        sys.exit(1)
+
+    try:
+        ukc.write_config_files(kconf, using_config, app_default_config,
+                              save_min=not no_save)
+    except OSError as e:
+        logger.error(f"Cannot write config: {e}")
+        sys.exit(1)
+
+    if not no_save:
+        # Re-derive so using.config is byte-identical to what
+        # [config choice] would produce from the new app_default.config.
+        # Skipped under --no-save, where app_default.config still holds
+        # the old values and would undo what we just did.
+        _defconfig(app_default_config, using_config,
+                   params["catalog_kconfig"])
+
+    if keep_build:
+        if identity_changed:
+            logger.warning("Platform/board identity changed "
+                           f"({identity_diff}) but -k was given; run "
+                           "[tos.py clean -f] before building.")
+    elif identity_changed:
+        logger.warning("Platform/board identity changed "
+                       f"({identity_diff}); full clean needed.")
+        logger.warning("Existing values were carried over. Use "
+                       "[tos.py config choice] for a clean switch.")
+        full_clean_project()
+        init_using_config(force=True)
+    else:
+        for path in _invalidate_derived_artifacts():
+            logger.info(f"Invalidated: {path}")
+
+    if no_save:
+        logger.note(f"Updated: {using_config}")
+        logger.warning("--no-save: app_default.config is unchanged, so "
+                       "this only affects the next build.")
+    else:
+        logger.note(f"Updated: {app_default_config}")
+    sys.exit(0)
+
+
+@click.command(help="Print config symbol value(s).")
+@click.argument('names', nargs=-1, required=True, metavar='CONFIG_NAME...')
+@click.option('-a', '--all', 'show_all',
+              is_flag=True, default=False,
+              help="Show type, prompt, visibility and dependencies.")
+@click.option('-j', '--json', 'as_json',
+              is_flag=True, default=False,
+              help="Output as JSON.")
+def config_get_exec(names, show_all, as_json):
+    '''
+    Read-only. Values go to stdout, diagnostics to stderr, so
+    --json output can be piped straight into a parser.
+    '''
+    logger = get_logger()
+    kconf = _load_current_kconfig()
+
+    missing = []
+    payload = {}
+    blocks = []
+    for name in names:
+        cfg_name = ukc.full_name(name)
+        sym = ukc.find_symbol(kconf, name)
+        if sym is None:
+            missing.append(cfg_name)
+            payload[cfg_name] = None
+            continue
+        if show_all:
+            payload[cfg_name] = ukc.symbol_info(sym)
+            blocks.append(ukc.format_symbol_info(sym))
+        else:
+            payload[cfg_name] = ukc.symbol_value(sym)
+            if len(names) == 1:
+                blocks.append(sym.str_value)
+            else:
+                blocks.append(f"{cfg_name}={sym.str_value}")
+
+    if as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        for block in blocks:
+            print(block)
+
+    for name in missing:
+        logger.error(f"{name}: unknown symbol")
+    sys.exit(1 if missing else 0)
+
+
+@click.command(help="List the effective config.")
+@click.option('-p', '--pattern',
+              default=None, metavar='PATTERN',
+              help="Filter symbol names by substring, or by glob if "
+                   "the pattern contains any of *?[.")
+@click.option('-j', '--json', 'as_json',
+              is_flag=True, default=False,
+              help="Output as JSON.")
+def config_list_exec(pattern, as_json):
+    '''
+    Read-only dump of using.config, read through kconfiglib so that
+    unset symbols show up as '# CONFIG_X is not set'.
+    '''
+    logger = get_logger()
+    kconf = _load_current_kconfig()
+
+    if as_json:
+        print(json.dumps(ukc.config_snapshot(kconf, pattern), indent=2))
+        sys.exit(0)
+
+    count = 0
+    for line in ukc.iter_config_lines(kconf, pattern):
+        print(line)
+        count += 1
+    if not count:
+        logger.warning(f"No symbol matched [{pattern}].")
+    sys.exit(0)
+
+
+@click.command(help="Compare two configs, expanded through Kconfig.")
+@click.argument('config_a', metavar='CONFIG_A')
+@click.argument('config_b', required=False, metavar='[CONFIG_B]')
+@click.option('-j', '--json', 'as_json',
+              is_flag=True, default=False,
+              help="Output as JSON.")
+def config_diff_exec(config_a, config_b, as_json):
+    '''
+    CONFIG_A/CONFIG_B are config names (resolved against the app config
+    dir and every board config dir) or paths. CONFIG_B defaults to the
+    current app_default.config.
+    '''
+    logger = get_logger()
+    init_using_config(force=False)
+    params = get_global_params()
+
+    path_a = _resolve_config_path(config_a)
+    if path_a is None:
+        logger.error(f"Config [{config_a}] not found.")
+        sys.exit(1)
+
+    if config_b is None:
+        path_b = params["app_default_config"]
+        label_b = "app_default.config"
+    else:
+        path_b = _resolve_config_path(config_b)
+        if path_b is None:
+            logger.error(f"Config [{config_b}] not found.")
+            sys.exit(1)
+        label_b = os.path.basename(path_b)
+    label_a = os.path.basename(path_a)
+
+    snap_a = _expand_min_config(path_a)
+    snap_b = _expand_min_config(path_b)
+
+    diff = {}
+    for name in sorted(set(snap_a) | set(snap_b)):
+        value_a = snap_a.get(name)
+        value_b = snap_b.get(name)
+        if value_a != value_b:
+            diff[name] = {"a": value_a, "b": value_b}
+
+    if as_json:
+        print(json.dumps({"a": label_a, "b": label_b, "diff": diff},
+                         indent=2))
+        sys.exit(0)
+
+    if not diff:
+        logger.note(f"No difference between {label_a} and {label_b}.")
+        sys.exit(0)
+
+    print(f"a: {label_a}")
+    print(f"b: {label_b}")
+    for name, values in diff.items():
+        value_a = values["a"] if values["a"] is not None else "(absent)"
+        value_b = values["b"] if values["b"] is not None else "(absent)"
+        print(f"{name}: {value_a} -> {value_b}")
+    sys.exit(0)
+
+
 @click.command(help="Save minimal config.")
-def config_save_exec():
+@click.option('-n', '--name',
+              default=None, metavar='NAME',
+              help="Config name to save (e.g. my_board). "
+                   "Non-interactive; prompts when omitted.")
+@click.option('-f', '--force',
+              is_flag=True, default=False,
+              help="Overwrite an existing config file.")
+def config_save_exec(name, force):
     '''
     1. Copy: app_default.config -> $APP_TOOT/config/xxx.config
     '''
@@ -185,16 +576,40 @@ def config_save_exec():
     app_default_config = params["app_default_config"]
 
     if not os.path.exists(app_default_config):
-        logger.error("Please run [tos.py menuconfig] first.")
+        logger.error("Please run [tos.py config menu] "
+                     "or [tos.py config set] first.")
         sys.exit(1)
 
-    saveconfig_name = input("Input save config name: ")
-    if not saveconfig_name.endswith(".config"):
-        saveconfig_name += ".config"
+    interactive = name is None
+    if interactive:
+        # isatty() is not dependable everywhere (MSYS/Git Bash reports a
+        # tty for a redirected stdin), so EOFError is the real guard
+        # against hanging or dying with a bare "Aborted!" in CI.
+        if not sys.stdin.isatty():
+            logger.error("Not a TTY: pass the name with -n NAME.")
+            sys.exit(1)
+        try:
+            name = input("Input save config name: ")
+        except EOFError:
+            logger.error("No input available: pass the name with -n NAME.")
+            sys.exit(1)
+
+    saveconfig_name = _normalize_save_name(name)
+    if not saveconfig_name:
+        logger.error(f"Invalid config name [{name}].")
+        sys.exit(1)
 
     app_configs_path = params["app_configs_path"]
     saveconfig = os.path.join(app_configs_path, saveconfig_name)
-    copy_file(app_default_config, saveconfig)
+    # The overwrite guard is scoped to -n so that the interactive flow
+    # keeps behaving exactly as before.
+    if not interactive and not force and os.path.exists(saveconfig):
+        logger.error(f"[{saveconfig}] exists, use -f to overwrite.")
+        sys.exit(1)
+
+    if not copy_file(app_default_config, saveconfig):
+        logger.error(f"Cannot save [{saveconfig}].")
+        sys.exit(1)
     logger.note(f"Success save: {saveconfig}")
     sys.exit(0)
 
@@ -202,6 +617,10 @@ def config_save_exec():
 CLIS = {
     "choice": config_choice_exec,
     "menu": config_menu_exec,
+    "set": config_set_exec,
+    "get": config_get_exec,
+    "list": config_list_exec,
+    "diff": config_diff_exec,
     "save": config_save_exec
 }
 

--- a/tools/cli_command/tests/test_cli_config.py
+++ b/tools/cli_command/tests/test_cli_config.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Unit tests for the non-exiting helpers in
+# tools/cli_command/cli_config.py
+#
+# Run from the repo root:
+#   python -m unittest tools.cli_command.tests.test_cli_config -v
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestNormalizeSaveName(unittest.TestCase):
+
+    def setUp(self):
+        import tools.cli_command.cli_config as m
+        self.normalize = m._normalize_save_name
+
+    def test_appends_config_suffix(self):
+        self.assertEqual(self.normalize("my_board"), "my_board.config")
+
+    def test_keeps_existing_suffix(self):
+        self.assertEqual(self.normalize("my_board.config"),
+                         "my_board.config")
+
+    def test_strips_whitespace(self):
+        self.assertEqual(self.normalize("  my_board  "),
+                         "my_board.config")
+
+    def test_rejects_empty(self):
+        self.assertEqual(self.normalize(""), "")
+        self.assertEqual(self.normalize("   "), "")
+        self.assertEqual(self.normalize(None), "")
+
+    def test_rejects_forward_slash(self):
+        self.assertEqual(self.normalize("a/b"), "")
+
+    def test_rejects_backslash(self):
+        self.assertEqual(self.normalize("a\\b"), "")
+
+    def test_rejects_parent_traversal(self):
+        self.assertEqual(self.normalize("../evil"), "")
+        self.assertEqual(self.normalize(".."), "")
+
+
+class TestInvalidateDerivedArtifacts(unittest.TestCase):
+    '''
+    tools/kconfiglib/CMakeLists.txt only regenerates using.cmake and
+    tuya_kconfig.h when they are absent, so `config set` has to remove
+    them. It must never remove using.config, which it just wrote.
+    '''
+
+    def setUp(self):
+        import tools.cli_command.cli_config as m
+        self.m = m
+
+    def _run(self, build_path):
+        params = {"app_build_path": build_path}
+        with patch('tools.cli_command.cli_config.get_global_params',
+                   return_value=params), \
+             patch('tools.cli_command.cli_config.get_logger',
+                   return_value=MagicMock()):
+            return self.m._invalidate_derived_artifacts()
+
+    def _make_tree(self, build_path):
+        cache = os.path.join(build_path, "cache")
+        include = os.path.join(build_path, "include")
+        os.makedirs(cache)
+        os.makedirs(include)
+        paths = {
+            "cmake": os.path.join(cache, "using.cmake"),
+            "header": os.path.join(include, "tuya_kconfig.h"),
+            "config": os.path.join(cache, "using.config"),
+        }
+        for path in paths.values():
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write("placeholder\n")
+        return paths
+
+    def test_removes_using_cmake_and_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            build_path = os.path.join(tmp, ".build")
+            paths = self._make_tree(build_path)
+            removed = self._run(build_path)
+            self.assertFalse(os.path.exists(paths["cmake"]))
+            self.assertFalse(os.path.exists(paths["header"]))
+            self.assertEqual(sorted(removed),
+                             sorted([paths["cmake"], paths["header"]]))
+
+    def test_leaves_using_config_untouched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            build_path = os.path.join(tmp, ".build")
+            paths = self._make_tree(build_path)
+            self._run(build_path)
+            self.assertTrue(os.path.exists(paths["config"]))
+
+    def test_missing_files_is_not_an_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            build_path = os.path.join(tmp, ".build")
+            os.makedirs(build_path)
+            self.assertEqual(self._run(build_path), [])
+
+    def test_absent_build_dir_is_not_an_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            build_path = os.path.join(tmp, "no_such_build")
+            self.assertEqual(self._run(build_path), [])
+
+
+class TestDerivedArtifactsList(unittest.TestCase):
+
+    def test_matches_cmake_generated_files(self):
+        '''
+        Guard against the list drifting from
+        tools/kconfiglib/CMakeLists.txt, which is what makes the
+        invalidation necessary in the first place.
+        '''
+        import tools.cli_command.cli_config as m
+        names = [parts[-1] for parts in m.DERIVED_ARTIFACTS]
+        self.assertIn("using.cmake", names)
+        self.assertIn("tuya_kconfig.h", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/tests/test_config_e2e.py
+++ b/tools/cli_command/tests/test_config_e2e.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# End-to-end tests for the non-interactive `tos.py config` subcommands.
+# These load the real boards/ + src/ Kconfig tree, so they cover the
+# kconfiglib behaviour that the mini-fixture unit tests cannot. No
+# compilation and no toolchain is involved.
+#
+# Run from the repo root:
+#   TUYAOPEN_E2E=1 python -m unittest \
+#       tools.cli_command.tests.test_config_e2e -v
+# PowerShell:
+#   $env:TUYAOPEN_E2E="1"
+
+import os
+import sys
+import json
+import shutil
+import filecmp
+import hashlib
+import tempfile
+import subprocess
+import unittest
+
+
+OPEN_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+TOS_PY = os.path.join(OPEN_ROOT, "tos.py")
+SOURCE_APP = os.path.join(OPEN_ROOT, "apps", "tuya_cloud", "switch_demo")
+
+
+def _digest(path):
+    with open(path, 'rb') as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+@unittest.skipUnless(os.environ.get("TUYAOPEN_E2E") == "1",
+                     "set TUYAOPEN_E2E=1 to run the end-to-end tests")
+class ConfigE2EBase(unittest.TestCase):
+    '''
+    Runs every command against a throwaway copy of switch_demo.
+
+    The copy is mandatory: switch_demo/app_default.config is tracked by
+    git and `config set` rewrites it. Running from a temp dir also
+    proves the commands are cwd-independent, since open_root comes from
+    sys.argv[0] and CatalogKconfig sources absolute paths.
+    '''
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.app = os.path.join(self._tmp.name, "switch_demo")
+        os.makedirs(self.app)
+        # Only these two files matter to the config commands: the
+        # CMakeLists.txt satisfies check_proj_dir() and the config is
+        # the state under test. switch_demo has no app Kconfig.
+        for name in ("CMakeLists.txt", "app_default.config"):
+            shutil.copy(os.path.join(SOURCE_APP, name),
+                        os.path.join(self.app, name))
+        self.app_default = os.path.join(self.app, "app_default.config")
+        self.using = os.path.join(self.app, ".build", "cache",
+                                  "using.config")
+
+    def run_config(self, *args, **kwargs):
+        cmd = [sys.executable, TOS_PY, "config"] + list(args)
+        return subprocess.run(cmd, cwd=self.app, capture_output=True,
+                              text=True, **kwargs)
+
+    def read(self, path):
+        with open(path, encoding='utf-8') as f:
+            return f.read()
+
+
+class TestConfigGet(ConfigE2EBase):
+
+    def test_get_prints_bare_value_for_single_symbol(self):
+        result = self.run_config(
+            "get", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "4096")
+
+    def test_get_json_stdout_is_not_polluted_by_logs(self):
+        result = self.run_config(
+            "get", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN",
+            "CONFIG_PLATFORM_CHOICE", "-j")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN"], 4096)
+        self.assertEqual(payload["CONFIG_PLATFORM_CHOICE"], "T5AI")
+        # The "[INFO]: Running tos.py ..." banner must be on stderr.
+        self.assertIn("Running tos.py", result.stderr)
+
+    def test_get_accepts_name_without_config_prefix(self):
+        result = self.run_config("get", "PLATFORM_CHOICE")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "T5AI")
+
+    def test_get_all_shows_attributes(self):
+        result = self.run_config("get", "-a", "CONFIG_BOARD_ENABLE_T5AI")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("bool", result.stdout)
+        self.assertIn("configurable: no", result.stdout)
+
+    def test_get_unknown_symbol_exits_nonzero(self):
+        result = self.run_config("get", "CONFIG_NOPE_XYZ")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown symbol", result.stderr)
+
+    def test_get_unknown_symbol_still_emits_valid_json(self):
+        result = self.run_config("get", "CONFIG_NOPE_XYZ", "-j")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(json.loads(result.stdout),
+                         {"CONFIG_NOPE_XYZ": None})
+
+    def test_get_does_not_mutate_configs(self):
+        self.run_config("list")
+        before_default = _digest(self.app_default)
+        before_using = _digest(self.using)
+        self.run_config("get", "CONFIG_PLATFORM_CHOICE", "-a")
+        self.assertEqual(_digest(self.app_default), before_default)
+        self.assertEqual(_digest(self.using), before_using)
+
+
+class TestConfigList(ConfigE2EBase):
+
+    def test_list_filtered(self):
+        result = self.run_config("list", "-p", "BOARD_CHOICE")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("CONFIG_BOARD_CHOICE_T5AI=y", result.stdout)
+
+    def test_list_shows_unset_symbols(self):
+        result = self.run_config("list", "-p", "BOARD_CHOICE")
+        self.assertIn("is not set", result.stdout)
+
+    def test_list_json_parses(self):
+        result = self.run_config("list", "-p", "MBEDTLS", "-j")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN"], 4096)
+
+    def test_list_no_match_warns_but_succeeds(self):
+        result = self.run_config("list", "-p", "ZZZ_NO_SUCH_THING")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertIn("No symbol matched", result.stderr)
+
+
+class TestConfigSet(ConfigE2EBase):
+
+    def test_set_int_roundtrip(self):
+        result = self.run_config(
+            "set", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192",
+                      self.read(self.app_default))
+        self.assertIn("CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192",
+                      self.read(self.using))
+        readback = self.run_config(
+            "get", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN", "-j")
+        self.assertEqual(
+            json.loads(readback.stdout)
+            ["CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN"], 8192)
+
+    def test_set_does_not_leave_a_dot_old_backup(self):
+        self.run_config("set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        self.assertFalse(os.path.exists(self.using + ".old"))
+
+    def test_set_accepts_name_without_config_prefix(self):
+        result = self.run_config("set", "ENABLE_LIBLVGL=y")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("CONFIG_ENABLE_LIBLVGL=y",
+                      self.read(self.app_default))
+
+    def test_min_config_stays_minimal(self):
+        self.run_config("set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        lines = [ln for ln in self.read(self.app_default).splitlines()
+                 if ln.strip() and not ln.startswith("#")]
+        # Only the board choice and the one overridden value differ
+        # from the Kconfig defaults.
+        self.assertEqual(len(lines), 2, lines)
+
+    def test_set_unknown_symbol_is_atomic(self):
+        self.run_config("list")  # materialise .build first
+        before = _digest(self.app_default)
+        result = self.run_config("set", "CONFIG_NOPE_XYZ=y",
+                                 "ENABLE_LIBLVGL=y")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown symbol", result.stderr)
+        self.assertEqual(_digest(self.app_default), before)
+        self.assertNotIn("CONFIG_ENABLE_LIBLVGL=y", self.read(self.using))
+
+    def test_set_promptless_symbol_fails(self):
+        before = _digest(self.app_default)
+        result = self.run_config("set", "CONFIG_BOARD_ENABLE_T5AI=n")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no prompt", result.stderr)
+        self.assertEqual(_digest(self.app_default), before)
+
+    def test_set_bad_token_fails(self):
+        result = self.run_config("set", "CONFIG_NO_EQUALS_SIGN")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no '='", result.stderr)
+
+    def test_set_without_arguments_fails(self):
+        result = self.run_config("set")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Nothing to do", result.stderr)
+
+    def test_set_choice_propagates_to_derived_symbols(self):
+        result = self.run_config("set", "CONFIG_BOARD_CHOICE_ESP32=y")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("identity changed", result.stderr)
+        body = self.read(self.app_default)
+        self.assertIn("CONFIG_BOARD_CHOICE_ESP32=y", body)
+        self.assertNotIn("CONFIG_BOARD_CHOICE_T5AI=y", body)
+        readback = self.run_config("get", "PLATFORM_CHOICE",
+                                   "CHIP_CHOICE", "-j")
+        payload = json.loads(readback.stdout)
+        self.assertEqual(payload["CONFIG_PLATFORM_CHOICE"], "ESP32")
+        self.assertEqual(payload["CONFIG_CHIP_CHOICE"], "esp32")
+
+    def test_unset_reverts_to_default(self):
+        self.run_config("set", "ENABLE_LIBLVGL=y")
+        self.assertIn("CONFIG_ENABLE_LIBLVGL=y",
+                      self.read(self.app_default))
+        result = self.run_config("set", "-u", "CONFIG_ENABLE_LIBLVGL")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("CONFIG_ENABLE_LIBLVGL=y",
+                         self.read(self.app_default))
+
+    def test_unset_unknown_symbol_fails(self):
+        result = self.run_config("set", "-u", "CONFIG_NOPE_XYZ")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown symbol", result.stderr)
+
+    def test_no_save_leaves_app_default_untouched(self):
+        self.run_config("list")
+        before = _digest(self.app_default)
+        result = self.run_config(
+            "set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192", "--no-save")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(_digest(self.app_default), before)
+        self.assertIn("CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192",
+                      self.read(self.using))
+
+    def test_set_invalidates_derived_artifacts(self):
+        self.run_config("list")  # materialise .build/cache
+        cache = os.path.join(self.app, ".build", "cache")
+        include = os.path.join(self.app, ".build", "include")
+        os.makedirs(include, exist_ok=True)
+        using_cmake = os.path.join(cache, "using.cmake")
+        header = os.path.join(include, "tuya_kconfig.h")
+        for path in (using_cmake, header):
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write("stale\n")
+
+        result = self.run_config(
+            "set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(os.path.exists(using_cmake))
+        self.assertFalse(os.path.exists(header))
+        # The config we just wrote must survive the invalidation.
+        self.assertTrue(os.path.exists(self.using))
+
+    def test_no_save_refuses_an_identity_change(self):
+        '''
+        A board switch forces a full clean, which rebuilds using.config
+        from app_default.config. Under --no-save that file still holds
+        the old board, so the combination would silently discard the
+        change. It must be refused instead.
+        '''
+        self.run_config("list")
+        before = _digest(self.app_default)
+        result = self.run_config("set", "CONFIG_BOARD_CHOICE_ESP32=y",
+                                 "--no-save")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--no-save cannot express that", result.stderr)
+        self.assertEqual(_digest(self.app_default), before)
+        readback = self.run_config("get", "PLATFORM_CHOICE")
+        self.assertEqual(readback.stdout.strip(), "T5AI")
+
+    def test_identity_change_with_keep_build_warns_instead(self):
+        result = self.run_config("set", "CONFIG_BOARD_CHOICE_ESP32=y", "-k")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("clean -f", result.stderr)
+
+    def test_keep_build_preserves_derived_artifacts(self):
+        self.run_config("list")
+        using_cmake = os.path.join(self.app, ".build", "cache",
+                                   "using.cmake")
+        with open(using_cmake, 'w', encoding='utf-8') as f:
+            f.write("stale\n")
+        result = self.run_config(
+            "set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192", "-k")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(os.path.exists(using_cmake))
+
+
+class TestConfigDiff(ConfigE2EBase):
+
+    def test_diff_of_equivalent_configs_reports_no_difference(self):
+        '''
+        switch_demo just selects the T5AI board, so its expansion is
+        identical to the board default even though the two minimal
+        files are not byte-identical. A textual diff would show noise
+        here; an expanded diff correctly shows nothing.
+        '''
+        result = self.run_config("diff", "T5AI")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertIn("No difference", result.stderr)
+
+    def test_diff_reports_a_changed_symbol(self):
+        self.run_config("set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        result = self.run_config("diff", "T5AI")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("a: T5AI.config", result.stdout)
+        self.assertIn("b: app_default.config", result.stdout)
+        self.assertIn("CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN",
+                      result.stdout)
+        self.assertIn("-> 8192", result.stdout)
+
+    def test_diff_across_boards_shows_platform_change(self):
+        result = self.run_config("diff", "T5AI", "ESP32-C3")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("CONFIG_PLATFORM_CHOICE: T5AI -> ESP32",
+                      result.stdout)
+
+    def test_diff_json_parses(self):
+        self.run_config("set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        result = self.run_config("diff", "T5AI", "-j")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["a"], "T5AI.config")
+        entry = payload["diff"][
+            "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN"]
+        self.assertEqual(entry["b"], "8192")
+
+    def test_diff_unknown_config_fails(self):
+        result = self.run_config("diff", "no_such_config")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not found", result.stderr)
+
+
+class TestConfigSave(ConfigE2EBase):
+
+    def test_save_non_interactive(self):
+        result = self.run_config("save", "-n", "ci_smoke")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        saved = os.path.join(self.app, "config", "ci_smoke.config")
+        self.assertTrue(os.path.exists(saved))
+        self.assertTrue(filecmp.cmp(saved, self.app_default, shallow=False))
+
+    def test_save_refuses_to_overwrite_without_force(self):
+        self.run_config("save", "-n", "ci_smoke")
+        result = self.run_config("save", "-n", "ci_smoke")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("use -f to overwrite", result.stderr)
+
+    def test_save_force_overwrites(self):
+        self.run_config("save", "-n", "ci_smoke")
+        result = self.run_config("save", "-n", "ci_smoke", "-f")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_save_rejects_path_traversal(self):
+        result = self.run_config("save", "-n", "../evil")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Invalid config name", result.stderr)
+
+    def test_save_without_name_does_not_hang(self):
+        result = self.run_config("save", stdin=subprocess.DEVNULL,
+                                 timeout=120)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("-n NAME", result.stderr)
+
+    def test_saved_config_is_selectable_again(self):
+        self.run_config("set", "ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=8192")
+        self.run_config("save", "-n", "ci_smoke")
+        result = self.run_config("choice", "-c", "ci_smoke.config")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        readback = self.run_config(
+            "get", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN")
+        self.assertEqual(readback.stdout.strip(), "8192")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/tests/test_util_kconfig.py
+++ b/tools/cli_command/tests/test_util_kconfig.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Unit tests for tools/cli_command/util_kconfig.py
+#
+# Run from the repo root:
+#   python -m unittest tools.cli_command.tests.test_util_kconfig -v
+
+import os
+import json
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+# A tiny Kconfig tree that still covers every branch of the module:
+# every symbol type, a prompt-less symbol, a dependency-guarded symbol
+# and a choice with a derived string.
+FIXTURE_KCONFIG = '''
+config PROMPTED_BOOL
+    bool "prompted bool"
+
+config PROMPTLESS_BOOL
+    bool
+    default y
+
+config GUARD
+    bool "guard"
+
+config GUARDED
+    bool "guarded"
+    depends on GUARD
+
+config NUM
+    int "num"
+    default 4096
+
+config HEXNUM
+    hex "hexnum"
+    default 0x10
+
+config TEXT
+    string "text"
+    default "hello"
+
+choice
+    prompt "pick"
+    default PICK_A
+
+config PICK_A
+    bool "A"
+
+config PICK_B
+    bool "B"
+
+endchoice
+
+config PICK_NAME
+    string
+    default "a" if PICK_A
+    default "b" if PICK_B
+'''
+
+IDENTITY_KCONFIG = '''
+config PLATFORM_CHOICE
+    string "platform"
+    default "T5AI"
+
+config CHIP_CHOICE
+    string "chip"
+    default "t5ai"
+'''
+
+
+class KconfigFixture(unittest.TestCase):
+    '''
+    Base class: writes a Kconfig file into a temp dir and loads it.
+    '''
+
+    KCONFIG_TEXT = FIXTURE_KCONFIG
+
+    def setUp(self):
+        import tools.cli_command.util_kconfig as m
+        self.m = m
+        self._logger_patch = patch(
+            'tools.cli_command.util_kconfig.get_logger',
+            return_value=MagicMock())
+        self._logger_patch.start()
+        self.addCleanup(self._logger_patch.stop)
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = self._tmp.name
+
+        self.kconfig_path = os.path.join(self.tmp, "Kconfig")
+        with open(self.kconfig_path, 'w', encoding='utf-8') as f:
+            f.write(self.KCONFIG_TEXT)
+        self.dot_config = os.path.join(self.tmp, "using.config")
+        self.min_config = os.path.join(self.tmp, "min.config")
+
+    def load(self):
+        return self.m.load_kconfig(self.kconfig_path, self.dot_config)
+
+    def sym(self, kconf, name):
+        return self.m.find_symbol(kconf, name)
+
+
+class TestStripPrefix(KconfigFixture):
+
+    def test_strips_config_prefix(self):
+        self.assertEqual(self.m.strip_prefix("CONFIG_FOO"), "FOO")
+
+    def test_leaves_bare_name(self):
+        self.assertEqual(self.m.strip_prefix("FOO"), "FOO")
+
+    def test_strips_only_one_layer(self):
+        self.assertEqual(self.m.strip_prefix("CONFIG_CONFIG_FOO"),
+                         "CONFIG_FOO")
+
+    def test_full_name_is_idempotent(self):
+        self.assertEqual(self.m.full_name("FOO"), "CONFIG_FOO")
+        self.assertEqual(self.m.full_name("CONFIG_FOO"), "CONFIG_FOO")
+
+
+class TestParseAssignment(KconfigFixture):
+
+    def test_strips_config_prefix(self):
+        self.assertEqual(self.m.parse_assignment("CONFIG_A=y"), ("A", "y"))
+
+    def test_accepts_bare_name(self):
+        self.assertEqual(self.m.parse_assignment("A=y"), ("A", "y"))
+
+    def test_rejects_token_without_equals(self):
+        with self.assertRaises(ValueError):
+            self.m.parse_assignment("CONFIG_A")
+
+    def test_rejects_empty_name(self):
+        with self.assertRaises(ValueError):
+            self.m.parse_assignment("=y")
+
+    def test_splits_on_first_equals_only(self):
+        self.assertEqual(self.m.parse_assignment("CONFIG_S=a=b"),
+                         ("S", "a=b"))
+
+    def test_strips_surrounding_quotes(self):
+        self.assertEqual(self.m.parse_assignment('CONFIG_S="v"'),
+                         ("S", "v"))
+
+    def test_keeps_inner_quotes(self):
+        self.assertEqual(self.m.parse_assignment('CONFIG_S=a"b'),
+                         ("S", 'a"b'))
+
+
+class TestNormalizeValue(KconfigFixture):
+
+    def test_bool_yes_variants(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "PROMPTED_BOOL")
+        for raw in ("y", "Y", "yes", "true", "TRUE", "1", "on"):
+            self.assertEqual(self.m.normalize_value(sym, raw), (True, "y"),
+                             msg=raw)
+
+    def test_bool_no_variants(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "PROMPTED_BOOL")
+        for raw in ("n", "N", "no", "false", "0", "off"):
+            self.assertEqual(self.m.normalize_value(sym, raw), (True, "n"),
+                             msg=raw)
+
+    def test_bool_rejects_garbage(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "PROMPTED_BOOL")
+        ok, _ = self.m.normalize_value(sym, "maybe")
+        self.assertFalse(ok)
+
+    def test_bool_rejects_module_value(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "PROMPTED_BOOL")
+        ok, _ = self.m.normalize_value(sym, "m")
+        self.assertFalse(ok)
+
+    def test_int_accepts_decimal(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "NUM")
+        self.assertEqual(self.m.normalize_value(sym, " 8192 "),
+                         (True, "8192"))
+
+    def test_int_rejects_non_numeric(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "NUM")
+        ok, _ = self.m.normalize_value(sym, "abc")
+        self.assertFalse(ok)
+
+    def test_int_rejects_hex_form(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "NUM")
+        ok, _ = self.m.normalize_value(sym, "0x10")
+        self.assertFalse(ok)
+
+    def test_hex_accepts_prefixed_and_bare(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "HEXNUM")
+        self.assertEqual(self.m.normalize_value(sym, "0x20"), (True, "0x20"))
+        self.assertEqual(self.m.normalize_value(sym, "20"), (True, "20"))
+
+    def test_hex_rejects_non_hex(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "HEXNUM")
+        ok, _ = self.m.normalize_value(sym, "zz")
+        self.assertFalse(ok)
+
+    def test_string_passthrough(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "TEXT")
+        self.assertEqual(self.m.normalize_value(sym, " keep me "),
+                         (True, " keep me "))
+
+
+class TestValueMatches(KconfigFixture):
+
+    def test_hex_compares_numerically(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "HEXNUM")
+        self.assertTrue(self.m.value_matches(sym, "0x10"))
+        self.assertTrue(self.m.value_matches(sym, "10"))
+        self.assertFalse(self.m.value_matches(sym, "0x11"))
+
+    def test_int_compares_numerically(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "NUM")
+        self.assertTrue(self.m.value_matches(sym, "4096"))
+        self.assertFalse(self.m.value_matches(sym, "4097"))
+
+    def test_string_compares_literally(self):
+        kconf = self.load()
+        sym = self.sym(kconf, "TEXT")
+        self.assertTrue(self.m.value_matches(sym, "hello"))
+        self.assertFalse(self.m.value_matches(sym, "Hello"))
+
+
+class TestFindSymbol(KconfigFixture):
+
+    def test_finds_with_and_without_prefix(self):
+        kconf = self.load()
+        self.assertIsNotNone(self.sym(kconf, "NUM"))
+        self.assertIsNotNone(self.sym(kconf, "CONFIG_NUM"))
+
+    def test_unknown_symbol_is_none(self):
+        kconf = self.load()
+        self.assertIsNone(self.sym(kconf, "NOPE_XYZ"))
+
+    def test_lowercase_name_resolves(self):
+        kconf = self.load()
+        self.assertIsNotNone(self.sym(kconf, "num"))
+
+
+class TestIsConfigurable(KconfigFixture):
+
+    def test_prompted_symbol_is_configurable(self):
+        kconf = self.load()
+        self.assertTrue(self.m.is_configurable(
+            self.sym(kconf, "PROMPTED_BOOL")))
+
+    def test_promptless_symbol_is_not(self):
+        kconf = self.load()
+        self.assertFalse(self.m.is_configurable(
+            self.sym(kconf, "PROMPTLESS_BOOL")))
+
+    def test_derived_string_is_not(self):
+        kconf = self.load()
+        self.assertFalse(self.m.is_configurable(
+            self.sym(kconf, "PICK_NAME")))
+
+
+class TestApplyAssignments(KconfigFixture):
+
+    def test_set_prompted_bool_succeeds(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(
+            kconf, [("PROMPTED_BOOL", "y")])
+        self.assertEqual(failed, [])
+        self.assertEqual(applied,
+                         [("CONFIG_PROMPTED_BOOL", "n", "y")])
+        self.assertEqual(self.sym(kconf, "PROMPTED_BOOL").str_value, "y")
+
+    def test_set_int_succeeds(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(kconf, [("NUM", "8192")])
+        self.assertEqual(failed, [])
+        self.assertEqual(self.sym(kconf, "NUM").str_value, "8192")
+
+    def test_set_hex_succeeds(self):
+        kconf = self.load()
+        _, failed = self.m.apply_assignments(kconf, [("HEXNUM", "0x20")])
+        self.assertEqual(failed, [])
+        self.assertEqual(self.sym(kconf, "HEXNUM").str_value, "0x20")
+
+    def test_set_string_succeeds(self):
+        kconf = self.load()
+        _, failed = self.m.apply_assignments(kconf, [("TEXT", "bye")])
+        self.assertEqual(failed, [])
+        self.assertEqual(self.sym(kconf, "TEXT").str_value, "bye")
+
+    def test_promptless_symbol_is_reported(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(
+            kconf, [("PROMPTLESS_BOOL", "n")])
+        self.assertEqual(applied, [])
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0][0], "CONFIG_PROMPTLESS_BOOL")
+        self.assertIn("no prompt", failed[0][1])
+
+    def test_hidden_symbol_reports_dependency(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(kconf,
+                                                  [("GUARDED", "y")])
+        self.assertEqual(applied, [])
+        self.assertEqual(len(failed), 1)
+        self.assertIn("GUARD", failed[0][1])
+
+    def test_hidden_symbol_succeeds_when_guard_set_first(self):
+        '''
+        Regression guard for assign-then-verify: GUARDED is invisible
+        until GUARD is set, so a validate-first implementation would
+        wrongly reject this batch.
+        '''
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(
+            kconf, [("GUARD", "y"), ("GUARDED", "y")])
+        self.assertEqual(failed, [])
+        self.assertEqual(len(applied), 2)
+        self.assertEqual(self.sym(kconf, "GUARDED").str_value, "y")
+
+    def test_unknown_symbol_is_reported(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(kconf,
+                                                  [("NOPE_XYZ", "y")])
+        self.assertEqual(applied, [])
+        self.assertEqual(failed, [("CONFIG_NOPE_XYZ", "unknown symbol")])
+
+    def test_invalid_value_for_type_is_reported(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(kconf, [("NUM", "abc")])
+        self.assertEqual(applied, [])
+        self.assertEqual(len(failed), 1)
+        self.assertIn("invalid value", failed[0][1])
+        self.assertIn("int", failed[0][1])
+
+    def test_choice_sibling_is_deselected(self):
+        kconf = self.load()
+        _, failed = self.m.apply_assignments(kconf, [("PICK_B", "y")])
+        self.assertEqual(failed, [])
+        self.assertEqual(self.sym(kconf, "PICK_A").str_value, "n")
+        self.assertEqual(self.sym(kconf, "PICK_B").str_value, "y")
+
+    def test_derived_string_follows_choice(self):
+        kconf = self.load()
+        self.assertEqual(self.sym(kconf, "PICK_NAME").str_value, "a")
+        self.m.apply_assignments(kconf, [("PICK_B", "y")])
+        self.assertEqual(self.sym(kconf, "PICK_NAME").str_value, "b")
+
+    def test_unchanged_value_still_counts_as_applied(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(kconf, [("NUM", "4096")])
+        self.assertEqual(failed, [])
+        self.assertEqual(applied, [("CONFIG_NUM", "4096", "4096")])
+
+    def test_partial_batch_reports_only_the_bad_one(self):
+        kconf = self.load()
+        applied, failed = self.m.apply_assignments(
+            kconf, [("NUM", "8192"), ("NOPE_XYZ", "y")])
+        self.assertEqual(len(applied), 1)
+        self.assertEqual(len(failed), 1)
+
+
+class TestApplyUnsets(KconfigFixture):
+
+    def test_unset_restores_default(self):
+        kconf = self.load()
+        self.m.apply_assignments(kconf, [("NUM", "8192")])
+        unset, failed = self.m.apply_unsets(kconf, ["CONFIG_NUM"])
+        self.assertEqual(failed, [])
+        self.assertEqual(unset, [("CONFIG_NUM", "8192", "4096")])
+        self.assertIsNone(self.sym(kconf, "NUM").user_value)
+
+    def test_unset_unknown_symbol_is_reported(self):
+        kconf = self.load()
+        unset, failed = self.m.apply_unsets(kconf, ["NOPE_XYZ"])
+        self.assertEqual(unset, [])
+        self.assertEqual(failed, [("CONFIG_NOPE_XYZ", "unknown symbol")])
+
+
+class TestKconfigConfigEnv(KconfigFixture):
+
+    def test_env_restored_after_block(self):
+        os.environ["KCONFIG_CONFIG"] = "sentinel"
+        self.addCleanup(os.environ.pop, "KCONFIG_CONFIG", None)
+        with self.m.kconfig_config_env("other"):
+            self.assertEqual(os.environ["KCONFIG_CONFIG"], "other")
+        self.assertEqual(os.environ["KCONFIG_CONFIG"], "sentinel")
+
+    def test_env_absent_stays_absent(self):
+        os.environ.pop("KCONFIG_CONFIG", None)
+        with self.m.kconfig_config_env("other"):
+            self.assertEqual(os.environ["KCONFIG_CONFIG"], "other")
+        self.assertNotIn("KCONFIG_CONFIG", os.environ)
+
+    def test_env_restored_on_exception(self):
+        os.environ.pop("KCONFIG_CONFIG", None)
+        with self.assertRaises(RuntimeError):
+            with self.m.kconfig_config_env("other"):
+                raise RuntimeError("boom")
+        self.assertNotIn("KCONFIG_CONFIG", os.environ)
+
+    def test_load_kconfig_does_not_leak_env(self):
+        os.environ.pop("KCONFIG_CONFIG", None)
+        self.load()
+        self.assertNotIn("KCONFIG_CONFIG", os.environ)
+
+
+class TestWriteConfigFiles(KconfigFixture):
+
+    def test_writes_both_files(self):
+        kconf = self.load()
+        self.m.apply_assignments(kconf, [("NUM", "8192")])
+        self.m.write_config_files(kconf, self.dot_config, self.min_config)
+        self.assertTrue(os.path.exists(self.dot_config))
+        self.assertTrue(os.path.exists(self.min_config))
+
+    def test_does_not_create_dot_old(self):
+        kconf = self.load()
+        self.m.write_config_files(kconf, self.dot_config, self.min_config)
+        self.m.write_config_files(kconf, self.dot_config, self.min_config)
+        self.assertFalse(os.path.exists(self.dot_config + ".old"))
+
+    def test_min_config_omits_defaulted_symbols(self):
+        kconf = self.load()
+        self.m.apply_assignments(kconf, [("NUM", "8192")])
+        self.m.write_config_files(kconf, self.dot_config, self.min_config)
+        with open(self.min_config, encoding='utf-8') as f:
+            body = f.read()
+        self.assertIn("CONFIG_NUM=8192", body)
+        self.assertNotIn("CONFIG_HEXNUM", body)
+        self.assertNotIn("CONFIG_TEXT", body)
+
+    def test_save_min_false_leaves_min_config_untouched(self):
+        kconf = self.load()
+        with open(self.min_config, 'w', encoding='utf-8') as f:
+            f.write("ORIGINAL\n")
+        self.m.apply_assignments(kconf, [("NUM", "8192")])
+        self.m.write_config_files(kconf, self.dot_config, self.min_config,
+                                  save_min=False)
+        with open(self.min_config, encoding='utf-8') as f:
+            self.assertEqual(f.read(), "ORIGINAL\n")
+        with open(self.dot_config, encoding='utf-8') as f:
+            self.assertIn("CONFIG_NUM=8192", f.read())
+
+    def test_roundtrip_through_min_config(self):
+        kconf = self.load()
+        self.m.apply_assignments(kconf, [("NUM", "8192"), ("PICK_B", "y")])
+        self.m.write_config_files(kconf, self.dot_config, self.min_config)
+        reloaded = self.m.load_kconfig(self.kconfig_path, self.min_config)
+        self.assertEqual(self.sym(reloaded, "NUM").str_value, "8192")
+        self.assertEqual(self.sym(reloaded, "PICK_NAME").str_value, "b")
+
+
+class TestSymbolValueAndInfo(KconfigFixture):
+
+    def test_symbol_value_types(self):
+        kconf = self.load()
+        self.assertIs(self.m.symbol_value(
+            self.sym(kconf, "PROMPTED_BOOL")), False)
+        self.assertEqual(self.m.symbol_value(self.sym(kconf, "NUM")), 4096)
+        self.assertEqual(self.m.symbol_value(self.sym(kconf, "HEXNUM")), 16)
+        self.assertEqual(self.m.symbol_value(self.sym(kconf, "TEXT")),
+                         "hello")
+
+    def test_info_includes_type_prompt_and_visibility(self):
+        kconf = self.load()
+        info = self.m.symbol_info(self.sym(kconf, "PROMPTED_BOOL"))
+        self.assertEqual(info["name"], "CONFIG_PROMPTED_BOOL")
+        self.assertEqual(info["type"], "bool")
+        self.assertEqual(info["prompt"], "prompted bool")
+        self.assertEqual(info["visibility"], "y")
+        self.assertTrue(info["configurable"])
+
+    def test_info_reports_dependency(self):
+        kconf = self.load()
+        info = self.m.symbol_info(self.sym(kconf, "GUARDED"))
+        self.assertEqual(info["depends_on"], "GUARD")
+        self.assertEqual(info["visibility"], "n")
+
+    def test_info_has_no_dependency_for_free_symbol(self):
+        kconf = self.load()
+        info = self.m.symbol_info(self.sym(kconf, "NUM"))
+        self.assertIsNone(info["depends_on"])
+        self.assertIsNone(info["selected_by"])
+
+    def test_promptless_symbol_marked_not_configurable(self):
+        kconf = self.load()
+        info = self.m.symbol_info(self.sym(kconf, "PROMPTLESS_BOOL"))
+        self.assertFalse(info["configurable"])
+        self.assertIsNone(info["prompt"])
+
+    def test_info_is_json_serialisable(self):
+        kconf = self.load()
+        for name in ("PROMPTED_BOOL", "NUM", "HEXNUM", "TEXT",
+                     "GUARDED", "PICK_NAME", "PROMPTLESS_BOOL"):
+            info = self.m.symbol_info(self.sym(kconf, name))
+            self.assertEqual(json.loads(json.dumps(info)), info)
+
+    def test_defined_at_uses_forward_slashes(self):
+        kconf = self.load()
+        info = self.m.symbol_info(self.sym(kconf, "NUM"))
+        self.assertTrue(info["defined_at"])
+        self.assertNotIn("\\", info["defined_at"][0])
+
+    def test_format_symbol_info_is_multiline(self):
+        kconf = self.load()
+        text = self.m.format_symbol_info(self.sym(kconf, "GUARDED"))
+        self.assertIn("CONFIG_GUARDED=", text)
+        self.assertIn("type", text)
+        self.assertIn("depends on", text)
+
+
+class TestMatchName(KconfigFixture):
+
+    def test_none_matches_all(self):
+        self.assertTrue(self.m.match_name("CONFIG_ANY", None))
+        self.assertTrue(self.m.match_name("CONFIG_ANY", ""))
+
+    def test_substring_is_case_insensitive(self):
+        self.assertTrue(self.m.match_name("CONFIG_ENABLE_WIFI", "wifi"))
+        self.assertTrue(self.m.match_name("CONFIG_ENABLE_WIFI", "WIFI"))
+
+    def test_non_match(self):
+        self.assertFalse(self.m.match_name("CONFIG_ENABLE_WIFI", "bt"))
+
+    def test_glob_pattern(self):
+        self.assertTrue(self.m.match_name("CONFIG_ENABLE_WIFI",
+                                          "CONFIG_ENABLE_*"))
+        self.assertFalse(self.m.match_name("CONFIG_ENABLE_WIFI",
+                                           "CONFIG_BOARD_*"))
+
+
+class TestIterConfigLinesAndSnapshots(KconfigFixture):
+
+    def test_includes_not_set_comment_lines(self):
+        kconf = self.load()
+        lines = list(self.m.iter_config_lines(kconf))
+        self.assertIn("# CONFIG_PROMPTED_BOOL is not set", lines)
+
+    def test_respects_pattern(self):
+        kconf = self.load()
+        lines = list(self.m.iter_config_lines(kconf, "PICK"))
+        self.assertTrue(lines)
+        for line in lines:
+            self.assertIn("PICK", line)
+
+    def test_order_matches_kconfig_order(self):
+        kconf = self.load()
+        lines = list(self.m.iter_config_lines(kconf))
+        joined = "\n".join(lines)
+        self.assertLess(joined.index("PROMPTED_BOOL"), joined.index("NUM"))
+        self.assertLess(joined.index("NUM"), joined.index("TEXT"))
+
+    def test_config_snapshot_is_typed(self):
+        kconf = self.load()
+        snapshot = self.m.config_snapshot(kconf)
+        self.assertEqual(snapshot["CONFIG_NUM"], 4096)
+        self.assertEqual(snapshot["CONFIG_HEXNUM"], 16)
+        self.assertIs(snapshot["CONFIG_PROMPTED_BOOL"], False)
+
+    def test_raw_snapshot_is_strings(self):
+        kconf = self.load()
+        snapshot = self.m.raw_snapshot(kconf)
+        self.assertEqual(snapshot["CONFIG_NUM"], "4096")
+        self.assertEqual(snapshot["CONFIG_HEXNUM"], "0x10")
+        self.assertEqual(snapshot["CONFIG_PROMPTED_BOOL"], "n")
+
+    def test_snapshot_respects_pattern(self):
+        kconf = self.load()
+        snapshot = self.m.config_snapshot(kconf, "PICK")
+        self.assertTrue(snapshot)
+        for name in snapshot:
+            self.assertIn("PICK", name)
+
+
+class TestIdentityValuesMissing(KconfigFixture):
+
+    def test_missing_identity_syms_are_omitted(self):
+        kconf = self.load()
+        self.assertEqual(self.m.identity_values(kconf), {})
+
+
+class TestIdentityValuesPresent(KconfigFixture):
+
+    KCONFIG_TEXT = IDENTITY_KCONFIG
+
+    def test_reports_present_identity_syms(self):
+        kconf = self.load()
+        self.assertEqual(self.m.identity_values(kconf),
+                         {"PLATFORM_CHOICE": "T5AI",
+                          "CHIP_CHOICE": "t5ai"})
+
+    def test_detects_change(self):
+        kconf = self.load()
+        before = self.m.identity_values(kconf)
+        self.m.apply_assignments(kconf, [("PLATFORM_CHOICE", "ESP32")])
+        after = self.m.identity_values(kconf)
+        self.assertNotEqual(before, after)
+        self.assertEqual(after["PLATFORM_CHOICE"], "ESP32")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/tests/test_util_subprocess.py
+++ b/tools/cli_command/tests/test_util_subprocess.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Unit tests for tools/cli_command/util.py::do_subprocess
+#
+# Run from the repo root:
+#   python -m unittest tools.cli_command.tests.test_util_subprocess -v
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+# Writes a marker file relative to the process working directory, then
+# exits with the code given as argv[1]. Lives outside the directory it
+# is asked to run in, so the marker's location proves where the child
+# actually ran.
+CHILD_SCRIPT = '''
+import sys
+with open("marker.txt", "w") as f:
+    f.write("ok")
+sys.exit(int(sys.argv[1]))
+'''
+
+
+class TestDoSubprocess(unittest.TestCase):
+
+    def setUp(self):
+        import tools.cli_command.util as m
+        self.m = m
+        self._logger_patch = patch('tools.cli_command.util.get_logger',
+                                   return_value=MagicMock())
+        self._logger_patch.start()
+        self.addCleanup(self._logger_patch.stop)
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.script_dir = os.path.join(self._tmp.name, "scripts")
+        self.work_dir = os.path.join(self._tmp.name, "work")
+        os.makedirs(self.script_dir)
+        os.makedirs(self.work_dir)
+        self.script = os.path.join(self.script_dir, "child.py")
+        with open(self.script, 'w', encoding='utf-8') as f:
+            f.write(CHILD_SCRIPT)
+
+    def child_cmd(self, exit_code=0):
+        return f'"{sys.executable}" "{self.script}" {exit_code}'
+
+    def test_cwd_is_applied(self):
+        '''
+        The regression this guards: the old implementation built
+        "cd <dir> && <cmd>" and ran it through os.system, whose cmd.exe
+        `cd` does not switch drives without /d. On Windows the temp dir
+        is usually on a different drive from the checkout, so this also
+        exercises the cross-drive case that used to fail silently.
+        '''
+        ret = self.m.do_subprocess(self.child_cmd(), cwd=self.work_dir)
+        self.assertEqual(ret, 0)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.work_dir, "marker.txt")))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.script_dir, "marker.txt")))
+        self.assertFalse(os.path.exists(
+            os.path.join(os.getcwd(), "marker.txt")))
+
+    def test_cwd_is_applied_across_drives(self):
+        '''
+        Explicitly named so a failure points at the drive handling.
+        Skipped on single-drive layouts and on POSIX.
+        '''
+        here = os.path.splitdrive(os.path.abspath(os.getcwd()))[0]
+        there = os.path.splitdrive(os.path.abspath(self.work_dir))[0]
+        if not here or here.lower() == there.lower():
+            self.skipTest("cwd and temp dir are on the same drive")
+        ret = self.m.do_subprocess(self.child_cmd(), cwd=self.work_dir)
+        self.assertEqual(ret, 0)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.work_dir, "marker.txt")))
+
+    def test_returns_zero_on_success(self):
+        self.assertEqual(
+            self.m.do_subprocess(self.child_cmd(0), cwd=self.work_dir), 0)
+
+    def test_returns_the_child_exit_code(self):
+        '''
+        os.system returned a wait status on POSIX (exit 3 -> 768);
+        subprocess.call reports the exit code itself on both platforms.
+        '''
+        self.assertEqual(
+            self.m.do_subprocess(self.child_cmd(3), cwd=self.work_dir), 3)
+
+    def test_missing_cwd_returns_nonzero_without_raising(self):
+        missing = os.path.join(self._tmp.name, "no_such_dir")
+        ret = self.m.do_subprocess(self.child_cmd(), cwd=missing)
+        self.assertNotEqual(ret, 0)
+
+    def test_cwd_pointing_at_a_file_returns_nonzero(self):
+        ret = self.m.do_subprocess(self.child_cmd(), cwd=self.script)
+        self.assertNotEqual(ret, 0)
+
+    def test_empty_cmd_returns_zero(self):
+        self.assertEqual(self.m.do_subprocess(""), 0)
+        self.assertEqual(self.m.do_subprocess(None), 0)
+
+    def test_without_cwd_runs_in_the_current_directory(self):
+        '''
+        Backward compatibility: the callers that pass absolute paths and
+        no cwd (rm_rf, porting_platform) must keep working.
+        '''
+        original = os.getcwd()
+        os.chdir(self.work_dir)
+        self.addCleanup(os.chdir, original)
+        ret = self.m.do_subprocess(self.child_cmd())
+        self.assertEqual(ret, 0)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.work_dir, "marker.txt")))
+
+    def test_shell_features_still_work(self):
+        '''
+        shell=True is retained: POSIX platform hooks are invoked as
+        ./platform_prepare.sh, and some commands rely on redirection.
+        '''
+        marker = os.path.join(self.work_dir, "shell.txt")
+        ret = self.m.do_subprocess(f'echo hello> "{marker}"',
+                                   cwd=self.work_dir)
+        self.assertEqual(ret, 0)
+        with open(marker, encoding='utf-8') as f:
+            self.assertIn("hello", f.read())
+
+
+class TestCallSitesPassCwd(unittest.TestCase):
+    '''
+    The build/clean paths must hand the directory to do_subprocess
+    instead of prefixing the command with "cd <dir> &&", which is what
+    broke cross-drive builds.
+    '''
+
+    def _assert_uses_cwd(self, module_path):
+        with open(module_path, encoding='utf-8') as f:
+            body = f.read()
+        self.assertNotIn('f"cd ', body)
+        self.assertNotIn('"cd {', body)
+
+    def test_cli_build_has_no_cd_prefix(self):
+        import tools.cli_command.cli_build as m
+        self._assert_uses_cwd(m.__file__)
+
+    def test_cli_clean_has_no_cd_prefix(self):
+        import tools.cli_command.cli_clean as m
+        self._assert_uses_cwd(m.__file__)
+
+    def test_util_git_has_no_cd_prefix(self):
+        import tools.cli_command.util_git as m
+        self._assert_uses_cwd(m.__file__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/util.py
+++ b/tools/cli_command/util.py
@@ -9,6 +9,7 @@ import click
 import datetime
 import platform
 import logging
+import subprocess
 import contextlib
 from typing import List
 
@@ -393,7 +394,21 @@ def parse_yaml(yaml_file: str) -> dict:
         return {}
 
 
-def do_subprocess(cmd: str) -> int:
+def do_subprocess(cmd: str, cwd: str = None) -> int:
+    '''
+    Run cmd through the shell and return its exit code (0 == success).
+
+    Pass the working directory as cwd rather than prefixing the command
+    with "cd <dir> &&". On Windows, os.system runs via `cmd.exe /c`,
+    whose `cd` does not switch drives without /d, so a cross-drive
+    "cd D:\\sdk && ..." silently ran in the original directory. Handing
+    cwd to the process also means the directory never goes through the
+    shell, so paths containing spaces stop breaking.
+
+    KeyboardInterrupt is deliberately not caught: Ctrl-C during a build
+    should abort the whole command, not report a build failure and move
+    on to the next step.
+    '''
     logger = get_logger()
 
     if not cmd:
@@ -402,11 +417,11 @@ def do_subprocess(cmd: str) -> int:
 
     logger.info(f">>> subprocess >>>\n{cmd}")
 
-    ret = 1  # 0 means success
     try:
-        ret = os.system(cmd)
+        return subprocess.call(cmd, shell=True, cwd=cwd)
     except Exception as e:
+        # Usually a missing or invalid cwd, which the old shell-level
+        # `cd` reported as a non-zero exit instead of raising.
         logger.error(f"Do subprocess error: {str(e)}")
         logger.info(f"do subprocess: {cmd}")
         return 1
-    return ret

--- a/tools/cli_command/util_git.py
+++ b/tools/cli_command/util_git.py
@@ -263,8 +263,8 @@ def download_submoudules(repo_path):
         return True
 
     logger.info("Downloading submoudules ...")
-    cmd = f"cd {repo_path} && git submodule update --init"
-    if 0 != do_subprocess(cmd):
+    cmd = "git submodule update --init"
+    if 0 != do_subprocess(cmd, cwd=repo_path):
         logger.error("Download submoudules failed.")
         return False
 

--- a/tools/cli_command/util_kconfig.py
+++ b/tools/cli_command/util_kconfig.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+# coding=utf-8
+##
+# @file util_kconfig.py
+# @brief Non-interactive Kconfig helpers built on kconfiglib.
+#
+# Pure logic only: no click, no sys.exit(), no path discovery. Callers
+# pass every path in. This keeps the module unit-testable without the
+# global state that tools/cli_command/util.py owns.
+
+import os
+import fnmatch
+import contextlib
+
+import kconfiglib
+from kconfiglib import Kconfig, expr_str, TYPE_TO_STR, TRI_TO_STR
+
+from tools.cli_command.util import get_logger
+
+
+CONFIG_PREFIX = "CONFIG_"
+
+# Symbols that pick the toolchain. cmake_configure() bakes these into
+# CMakeCache.txt as -DTOS_PROJECT_*, so changing one of them makes an
+# incremental reconfigure unreliable and requires a full clean.
+IDENTITY_SYMS = ("PLATFORM_CHOICE", "CHIP_CHOICE",
+                 "BOARD_CHOICE", "FRAMEWORK_CHOICE")
+
+_TRI_TYPES = (kconfiglib.BOOL, kconfiglib.TRISTATE)
+
+_BOOL_WORDS = {
+    "y": "y", "yes": "y", "true": "y", "1": "y", "on": "y",
+    "n": "n", "no": "n", "false": "n", "0": "n", "off": "n",
+    "m": "m", "module": "m",
+}
+
+
+@contextlib.contextmanager
+def kconfig_config_env(dot_config):
+    '''
+    Point KCONFIG_CONFIG at dot_config for the block, then restore it.
+    kconfiglib falls back to this variable whenever a filename is
+    omitted; leaving it set leaks into every later subprocess (cmake,
+    ninja, platform scripts), so it must not escape.
+    '''
+    had = "KCONFIG_CONFIG" in os.environ
+    old = os.environ.get("KCONFIG_CONFIG")
+    os.environ["KCONFIG_CONFIG"] = dot_config
+    try:
+        yield
+    finally:
+        if had:
+            os.environ["KCONFIG_CONFIG"] = old
+        else:
+            os.environ.pop("KCONFIG_CONFIG", None)
+
+
+def strip_prefix(name):
+    '''
+    CONFIG_FOO -> FOO ; FOO -> FOO. Strips one layer only, so a real
+    symbol literally named CONFIG_FOO stays reachable as CONFIG_CONFIG_FOO.
+    '''
+    name = name.strip()
+    if name.startswith(CONFIG_PREFIX):
+        return name[len(CONFIG_PREFIX):]
+    return name
+
+
+def full_name(name):
+    return CONFIG_PREFIX + strip_prefix(name)
+
+
+def parse_assignment(token):
+    '''
+    'CONFIG_A=y' -> ('A', 'y')
+
+    Splits on the first '=' only, so string values may contain '='.
+    One layer of surrounding double quotes is stripped so both
+    CONFIG_S="v" and CONFIG_S=v work. Raises ValueError when malformed.
+    '''
+    if "=" not in token:
+        raise ValueError(f"no '=' in assignment: '{token}'")
+    name, value = token.split("=", 1)
+    name = strip_prefix(name)
+    if not name:
+        raise ValueError(f"empty symbol name: '{token}'")
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        value = value[1:-1]
+    return name, value
+
+
+def load_kconfig(catalog_kconfig, dot_config):
+    '''
+    Load the Kconfig tree and the current dot-config on top of it.
+    Warnings are collected instead of printed so that --json output
+    stays clean; they are re-emitted at debug level.
+    '''
+    logger = get_logger()
+    with kconfig_config_env(dot_config):
+        kconf = Kconfig(catalog_kconfig, warn_to_stderr=False,
+                        suppress_traceback=True)
+        if os.path.exists(dot_config):
+            kconf.load_config(dot_config)
+    for warning in kconf.warnings:
+        logger.debug(warning)
+    return kconf
+
+
+def find_symbol(kconf, name):
+    '''
+    Look up a symbol by name, with or without the CONFIG_ prefix.
+    Returns None for unknown names and for symbols that are merely
+    referenced by an expression but never defined (no menu nodes).
+    '''
+    sym = kconf.syms.get(strip_prefix(name))
+    if sym is None:
+        sym = kconf.syms.get(strip_prefix(name).upper())
+    if sym is None or not sym.nodes:
+        return None
+    return sym
+
+
+def is_configurable(sym):
+    '''
+    True when the symbol has a prompt somewhere, i.e. a user can
+    actually assign it. Prompt-less symbols are derived values or are
+    forced by `default`/`select` in a board or platform Kconfig.
+    '''
+    return any(node.prompt for node in sym.nodes)
+
+
+def normalize_value(sym, raw):
+    '''
+    Coerce a command-line string into the form kconfiglib expects.
+    Returns (ok, value); ok is False when raw cannot be a value of
+    this symbol's type.
+    '''
+    if sym.orig_type in _TRI_TYPES:
+        word = _BOOL_WORDS.get(raw.strip().lower())
+        if word is None:
+            return False, raw
+        if word == "m" and sym.orig_type is kconfiglib.BOOL:
+            return False, raw
+        return True, word
+
+    if sym.orig_type is kconfiglib.INT:
+        try:
+            return True, str(int(raw.strip(), 10))
+        except ValueError:
+            return False, raw
+
+    if sym.orig_type is kconfiglib.HEX:
+        text = raw.strip()
+        try:
+            int(text, 16)
+        except ValueError:
+            return False, raw
+        return True, text
+
+    if sym.orig_type is kconfiglib.STRING:
+        return True, raw
+
+    return False, raw
+
+
+def value_matches(sym, wanted):
+    '''
+    Type-aware comparison of a requested value against the symbol's
+    effective value. int/hex compare numerically so that 0x10, 10 and
+    16 do not read as three different values.
+    '''
+    current = sym.str_value
+    if sym.orig_type is kconfiglib.INT:
+        try:
+            return int(current, 10) == int(wanted, 10)
+        except ValueError:
+            return False
+    if sym.orig_type is kconfiglib.HEX:
+        try:
+            return int(current, 16) == int(wanted, 16)
+        except ValueError:
+            return False
+    return current == wanted
+
+
+def _short_expr(expression, limit=160):
+    '''
+    Dependency expressions in this tree can run to several hundred
+    characters (every board OR'd together), which drowns the actual
+    error. Keep the head and point at `config get -a` for the rest.
+    '''
+    text = expr_str(expression)
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + " ... (see 'config get -a')"
+
+
+def diagnose_symbol(kconf, name, wanted):
+    '''
+    Explain why an assignment did not take effect. Only called for
+    values that failed the verify pass, so the message may assume
+    something is wrong.
+    '''
+    sym = find_symbol(kconf, name)
+    if sym is None:
+        return "unknown symbol"
+
+    if not is_configurable(sym):
+        return ("not user-configurable (no prompt); it is a derived "
+                "value or is forced by a board/platform default")
+
+    if sym.visibility == 0:
+        return ("hidden by unmet dependencies: "
+                f"{_short_expr(sym.direct_dep)}")
+
+    if sym.orig_type in _TRI_TYPES:
+        tri = kconfiglib.STR_TO_TRI.get(wanted)
+        if tri is not None and tri not in sym.assignable:
+            allowed = "/".join(TRI_TO_STR[t] for t in sym.assignable)
+            reason = (f"'{wanted}' is not assignable here "
+                      f"(allowed: {allowed or 'none'})")
+            if sym.rev_dep is not kconf.n:
+                reason += f"; selected by {_short_expr(sym.rev_dep)}"
+            return reason
+
+    type_name = TYPE_TO_STR[sym.orig_type]
+    return (f"assignment did not take effect: still '{sym.str_value}' "
+            f"(type {type_name})")
+
+
+def apply_unsets(kconf, names):
+    '''
+    Revert symbols to their Kconfig defaults by dropping the user
+    value. Returns (unset, failed); nothing is written to disk.
+      unset  = [(CONFIG_NAME, old_str_value, new_str_value)]
+      failed = [(CONFIG_NAME, reason)]
+    '''
+    unset = []
+    failed = []
+    touched = []
+    for name in names:
+        sym = find_symbol(kconf, name)
+        if sym is None:
+            failed.append((full_name(name), "unknown symbol"))
+            continue
+        old = sym.str_value
+        sym.unset_value()
+        touched.append((full_name(name), sym, old))
+    for cfg_name, sym, old in touched:
+        unset.append((cfg_name, old, sym.str_value))
+    return unset, failed
+
+
+def apply_assignments(kconf, pairs):
+    '''
+    Apply every assignment in order, then verify all of them.
+
+    Assign-then-verify rather than validate-then-assign: a symbol can
+    be invisible until an earlier assignment in the same batch reveals
+    it, so pre-validating would reject legitimate ordered batches such
+    as `CONFIG_PARENT=y CONFIG_CHILD=y`.
+
+    Verification is mandatory because kconfiglib's set_value() returns
+    True for prompt-less symbols whose value is then discarded.
+
+    Returns (applied, failed); nothing is written to disk.
+      applied = [(CONFIG_NAME, old_str_value, new_str_value)]
+      failed  = [(CONFIG_NAME, reason)]
+    '''
+    applied = []
+    failed = []
+    resolved = []
+
+    for name, raw in pairs:
+        cfg_name = full_name(name)
+        sym = find_symbol(kconf, name)
+        if sym is None:
+            failed.append((cfg_name, "unknown symbol"))
+            continue
+        ok, value = normalize_value(sym, raw)
+        if not ok:
+            type_name = TYPE_TO_STR[sym.orig_type]
+            failed.append((cfg_name, f"invalid value '{raw}' for type "
+                                     f"{type_name}"))
+            continue
+        old = sym.str_value
+        if not sym.set_value(value):
+            type_name = TYPE_TO_STR[sym.orig_type]
+            failed.append((cfg_name, f"invalid value '{raw}' for type "
+                                     f"{type_name}"))
+            continue
+        resolved.append((cfg_name, sym, value, old))
+
+    for cfg_name, sym, value, old in resolved:
+        if value_matches(sym, value):
+            applied.append((cfg_name, old, sym.str_value))
+        else:
+            failed.append((cfg_name,
+                           diagnose_symbol(kconf, sym.name, value)))
+
+    return applied, failed
+
+
+def symbol_value(sym):
+    '''
+    Typed python value, matching the conventions of
+    util.parse_config_file so scripts see one shape:
+    bool for bool, int for int/hex, str for string/tristate.
+    '''
+    text = sym.str_value
+    if sym.orig_type is kconfiglib.BOOL:
+        return text == "y"
+    if sym.orig_type is kconfiglib.TRISTATE:
+        return text
+    if sym.orig_type is kconfiglib.INT:
+        try:
+            return int(text, 10)
+        except ValueError:
+            return None
+    if sym.orig_type is kconfiglib.HEX:
+        try:
+            return int(text, 16)
+        except ValueError:
+            return None
+    return text
+
+
+def _prompt_text(sym):
+    for node in sym.nodes:
+        if node.prompt:
+            return node.prompt[0]
+    return None
+
+
+def _user_value_str(sym):
+    if sym.user_value is None:
+        return None
+    if sym.orig_type in _TRI_TYPES:
+        return TRI_TO_STR[sym.user_value]
+    return sym.user_value
+
+
+def symbol_info(sym):
+    '''
+    JSON-serialisable description of one symbol, for `config get -a`.
+    '''
+    kconf = sym.kconfig
+    direct = expr_str(sym.direct_dep)
+    return {
+        "name": CONFIG_PREFIX + sym.name,
+        "value": symbol_value(sym),
+        "str_value": sym.str_value,
+        "type": TYPE_TO_STR[sym.orig_type],
+        "prompt": _prompt_text(sym),
+        "visibility": TRI_TO_STR[sym.visibility],
+        "user_value": _user_value_str(sym),
+        "assignable": [TRI_TO_STR[t] for t in sym.assignable],
+        "configurable": is_configurable(sym),
+        "depends_on": None if sym.direct_dep is kconf.y else direct,
+        "selected_by": (None if sym.rev_dep is kconf.n
+                        else expr_str(sym.rev_dep)),
+        # CatalogKconfig sources with forward slashes while rsource
+        # appends the OS separator, so filenames come back mixed.
+        "defined_at": [f"{n.filename}:{n.linenr}".replace("\\", "/")
+                       for n in sym.nodes],
+    }
+
+
+def format_symbol_info(sym):
+    '''
+    Multi-line human-readable block for `config get -a`.
+    '''
+    info = symbol_info(sym)
+    lines = [f"{info['name']}={info['str_value']}"]
+    lines.append(f"  type        : {info['type']}")
+    lines.append(f"  prompt      : {info['prompt'] or '(none)'}")
+    lines.append(f"  visibility  : {info['visibility']}")
+    lines.append(f"  user value  : "
+                 f"{info['user_value'] if info['user_value'] else '(unset)'}")
+    lines.append(f"  assignable  : "
+                 f"{'/'.join(info['assignable']) or '(none)'}")
+    lines.append(f"  configurable: {'yes' if info['configurable'] else 'no'}")
+    if info["depends_on"]:
+        lines.append(f"  depends on  : {info['depends_on']}")
+    if info["selected_by"]:
+        lines.append(f"  selected by : {info['selected_by']}")
+    for where in info["defined_at"]:
+        lines.append(f"  defined at  : {where}")
+    return "\n".join(lines)
+
+
+def match_name(name, pattern):
+    '''
+    None matches everything. A pattern containing any of *?[ is treated
+    as a glob, otherwise as a case-insensitive substring.
+    '''
+    if not pattern:
+        return True
+    upper_name = name.upper()
+    upper_pattern = pattern.upper()
+    if any(ch in pattern for ch in "*?["):
+        return fnmatch.fnmatch(upper_name, upper_pattern)
+    return upper_pattern in upper_name
+
+
+def iter_config_lines(kconf, pattern=None):
+    '''
+    Yield one dot-config line per symbol, in Kconfig declaration order.
+    Uses Symbol.config_string, so unset bools appear as
+    '# CONFIG_X is not set' exactly as they do in using.config.
+    Menu comment headers are not reproduced.
+    '''
+    for sym in kconf.unique_defined_syms:
+        line = sym.config_string
+        if not line:
+            continue
+        if not match_name(CONFIG_PREFIX + sym.name, pattern):
+            continue
+        yield line.rstrip("\n")
+
+
+def config_snapshot(kconf, pattern=None):
+    '''
+    {CONFIG_NAME: typed value} for every writable symbol.
+    '''
+    snapshot = {}
+    for sym in kconf.unique_defined_syms:
+        if not sym.config_string:
+            continue
+        name = CONFIG_PREFIX + sym.name
+        if not match_name(name, pattern):
+            continue
+        snapshot[name] = symbol_value(sym)
+    return snapshot
+
+
+def raw_snapshot(kconf, pattern=None):
+    '''
+    {CONFIG_NAME: Kconfig string value} for every writable symbol.
+    Used for diffing, where 'n -> y' reads better than 'False -> True'
+    and every value is already JSON-safe.
+    '''
+    snapshot = {}
+    for sym in kconf.unique_defined_syms:
+        if not sym.config_string:
+            continue
+        name = CONFIG_PREFIX + sym.name
+        if not match_name(name, pattern):
+            continue
+        snapshot[name] = sym.str_value
+    return snapshot
+
+
+def identity_values(kconf):
+    '''
+    Current values of the toolchain-selecting symbols. A change here
+    means the CMake cache cannot be reused.
+    '''
+    values = {}
+    for name in IDENTITY_SYMS:
+        sym = kconf.syms.get(name)
+        if sym is not None:
+            values[name] = sym.str_value
+    return values
+
+
+def write_config_files(kconf, dot_config, min_config, save_min=True):
+    '''
+    Persist the in-memory configuration.
+
+    dot_config is written first on purpose: if the second write failed
+    we would rather have a fresh using.config and a stale
+    app_default.config (self-healing, since `config choice` and
+    `clean -f` rebuild using.config from it) than the reverse, which
+    init_using_config(force=False) would never notice.
+
+    save_old=False keeps kconfiglib from dropping a using.config.old
+    backup next to the real file.
+    '''
+    with kconfig_config_env(dot_config):
+        kconf.write_config(dot_config, save_old=False)
+        if save_min and min_config:
+            kconf.write_min_config(min_config)
+    pass


### PR DESCRIPTION
### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
