### PR TITLE
feat(tal_image): add edge-locked Atkinson and gamma-serpentine dithering

### DIFF
--- a/src/tal_image/include/tal_image_yuv422_to_binary.h
+++ b/src/tal_image/include/tal_image_yuv422_to_binary.h
@@ -3,7 +3,10 @@
  * @brief YUV422 to binary image conversion interface definitions.
  *
  * This header provides function declarations and type definitions for converting
- * YUV422 format images to binary (monochrome) format using various algorithms.
+ * YUV422 format images to binary (monochrome) format using various algorithms:
+ * fixed/adaptive/Otsu thresholding, Bayer dithering (4/8/16 levels), error
+ * diffusion (Floyd-Steinberg, Stucki, Jarvis), edge-locked Atkinson dithering,
+ * and gamma-corrected serpentine Floyd-Steinberg.
  *
  * @copyright Copyright (c) 2021-2025 Tuya Inc. All Rights Reserved.
  *
@@ -30,16 +33,18 @@ extern "C" {
  * @brief Binary conversion method enum
  */
 typedef enum {
-    TAL_IMAGE_MONO_MTH_FIXED = 0,       /* Fixed threshold */
-    TAL_IMAGE_MONO_MTH_ADAPTIVE,        /* Adaptive threshold */
-    TAL_IMAGE_MONO_MTH_OTSU,            /* Otsu's method */
-    TAL_IMAGE_MONO_MTH_BAYER8_DITHER,   /* 8-level grayscale Bayer dithering (3x3) */
-    TAL_IMAGE_MONO_MTH_BAYER4_DITHER,   /* 4-level grayscale Bayer dithering (2x2) */
-    TAL_IMAGE_MONO_MTH_BAYER16_DITHER,  /* 16-level grayscale Bayer dithering (4x4) */
-    TAL_IMAGE_MONO_MTH_FLOYD_STEINBERG, /* Floyd-Steinberg error diffusion */
-    TAL_IMAGE_MONO_MTH_STUCKI,          /* Stucki error diffusion */
-    TAL_IMAGE_MONO_MTH_JARVIS,          /* Jarvis-Judice-Ninke error diffusion */
-    TAL_IMAGE_MONO_MTH_COUNT            /* Total number of methods */
+    TAL_IMAGE_MONO_MTH_FIXED = 0,          /* Fixed threshold */
+    TAL_IMAGE_MONO_MTH_ADAPTIVE,           /* Adaptive threshold */
+    TAL_IMAGE_MONO_MTH_OTSU,               /* Otsu's method */
+    TAL_IMAGE_MONO_MTH_BAYER8_DITHER,      /* 8-level grayscale Bayer dithering (3x3) */
+    TAL_IMAGE_MONO_MTH_BAYER4_DITHER,      /* 4-level grayscale Bayer dithering (2x2) */
+    TAL_IMAGE_MONO_MTH_BAYER16_DITHER,     /* 16-level grayscale Bayer dithering (4x4) */
+    TAL_IMAGE_MONO_MTH_FLOYD_STEINBERG,    /* Floyd-Steinberg error diffusion */
+    TAL_IMAGE_MONO_MTH_STUCKI,             /* Stucki error diffusion */
+    TAL_IMAGE_MONO_MTH_JARVIS,             /* Jarvis-Judice-Ninke error diffusion */
+    TAL_IMAGE_MONO_MTH_EDGE_ATKINSON,      /* Edge-locked Atkinson dithering */
+    TAL_IMAGE_MONO_MTH_GAMMA_SERPENTINE,   /* Gamma-corrected serpentine Floyd-Steinberg */
+    TAL_IMAGE_MONO_MTH_COUNT               /* Total number of methods */
 } TAL_IMAGE_MONO_METHOD_E;
 
 /**

--- a/src/tal_image/src/tal_image_yuv422_to_binary.c
+++ b/src/tal_image/src/tal_image_yuv422_to_binary.c
@@ -14,6 +14,8 @@
  *
  */
 #include <string.h>
+#include <math.h>
+#include <stdbool.h>
 #include "tuya_cloud_types.h"
 #include "tal_memory.h"
 #include "tal_log.h"
@@ -22,6 +24,22 @@
 /***********************************************************
 ************************macro define************************
 ***********************************************************/
+/* Edge magnitude uses a raw 3x3 Laplacian (cheaper than a filtered edge map).
+ * Threshold 200 + brightness gate keeps edge-lock to ~3-9% of pixels; lower
+ * values flag too much texture as "edge" and crush detail to solid black. */
+#define EDGE_ATKINSON_THRESHOLD      200
+#define EDGE_ATKINSON_MAX_BRIGHTNESS 166 /* ~0.65 * 255, only darker pixels lock to black */
+/* Black/white split adapts per-frame via calculate_adaptive_threshold() since
+ * raw camera luma isn't gamma-corrected like a normal photo. Gamma further
+ * brightens dark scenes before dithering -- diffusion otherwise preserves
+ * the source's true (dark) average brightness, which reads as "crushed to
+ * black" on a small screen even with an adaptive threshold. */
+#define EDGE_ATKINSON_GAMMA 2.0f
+
+/* Gamma brightens shadow detail before dithering; scan direction alternates
+ * per row (serpentine) instead of always sweeping left-to-right. */
+#define GAMMA_SERPENTINE_GAMMA     1.45f
+#define GAMMA_SERPENTINE_THRESHOLD 128
 
 /***********************************************************
 ***********************Bayer Matrices***********************
@@ -595,6 +613,241 @@ static int yuv422_to_jarvis(const uint8_t *yuv422_data, int src_width, int src_h
     return 0;
 }
 
+/***********************************************************
+****Edge-locked Atkinson / Gamma-corrected serpentine********
+***********************************************************/
+/**
+ * @brief Clamped YUV422 luma sample, used by the edge-locked Atkinson method.
+ */
+static inline uint8_t get_luma_clamped(const uint8_t *yuv422_data, int src_width, int src_height, int x, int y)
+{
+    if (x < 0)
+        x = 0;
+    if (x >= src_width)
+        x = src_width - 1;
+    if (y < 0)
+        y = 0;
+    if (y >= src_height)
+        y = src_height - 1;
+    return yuv422_data[y * src_width * 2 + x * 2 + 1];
+}
+
+/**
+ * @brief Converts YUV422 to binary using edge-locked Atkinson dithering.
+ *
+ * Strong edges (raw 3x3 Laplacian magnitude, brightness-gated) are locked to
+ * solid black; the rest is Atkinson-diffused, giving a bold poster-like look
+ * with crisp outlines.
+ *
+ * @param yuv422_data Pointer to the source YUV422 image data.
+ * @param src_width Width of the source image.
+ * @param src_height Height of the source image.
+ * @param binary_data Pointer to the destination binary image buffer.
+ * @param dst_width Width of the destination image.
+ * @param dst_height Height of the destination image.
+ * @param invert Color inversion flag (1: bit=1->white, 0: bit=1->black).
+ * @return 0 on success, negative value on error.
+ */
+static int yuv422_to_edge_atkinson(const uint8_t *yuv422_data, int src_width, int src_height, uint8_t *binary_data,
+                                   int dst_width, int dst_height, int invert)
+{
+    static uint8_t edge_atkinson_gamma_lut[256];
+    static bool    edge_atkinson_gamma_lut_ready = false;
+
+    if (!edge_atkinson_gamma_lut_ready) {
+        for (int i = 0; i < 256; i++) {
+            float v = powf((float)i / 255.0f, 1.0f / EDGE_ATKINSON_GAMMA) * 255.0f;
+            edge_atkinson_gamma_lut[i] = (uint8_t)(v < 0.0f ? 0.0f : (v > 255.0f ? 255.0f : v));
+        }
+        edge_atkinson_gamma_lut_ready = true;
+    }
+
+    int binary_stride = (dst_width + 7) / 8;
+    int crop_offset = (src_width - dst_height) / 2; /* Dynamic: (src_width - dst_height) / 2 */
+    /* gamma(mean(raw)) approximates mean(gamma(raw)) without a second full-frame pass. */
+    uint8_t black_thresh = edge_atkinson_gamma_lut[calculate_adaptive_threshold(yuv422_data, src_width, src_height)];
+
+    /* 3 error rows with padding (Atkinson looks ahead 2 columns / 2 rows) */
+    int16_t *error_buffer = (int16_t *)Malloc((dst_width + 4) * 3 * sizeof(int16_t));
+    if (!error_buffer) {
+        return -1;
+    }
+
+    int16_t *curr_row = error_buffer + 2;
+    int16_t *next_row1 = error_buffer + dst_width + 6;
+    int16_t *next_row2 = error_buffer + 2 * (dst_width + 4) + 2;
+    memset(error_buffer, 0, (dst_width + 4) * 3 * sizeof(int16_t));
+
+    for (int dst_y = 0; dst_y < dst_height; dst_y++) {
+        int row_offset = dst_y * binary_stride;
+
+        for (int dst_x = 0; dst_x < dst_width; dst_x++) {
+            int src_x = dst_y + crop_offset;
+            int src_y = src_height - 1 - dst_x;
+
+            if (src_x < 0 || src_x >= src_width || src_y < 0 || src_y >= src_height) {
+                continue;
+            }
+
+            /* 3x3 Laplacian edge magnitude (locks strong edges to solid black) */
+            int center = get_luma_clamped(yuv422_data, src_width, src_height, src_x, src_y);
+            int sum8 = get_luma_clamped(yuv422_data, src_width, src_height, src_x - 1, src_y - 1) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x, src_y - 1) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x + 1, src_y - 1) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x - 1, src_y) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x + 1, src_y) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x - 1, src_y + 1) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x, src_y + 1) +
+                       get_luma_clamped(yuv422_data, src_width, src_height, src_x + 1, src_y + 1);
+            int edge_mag = 8 * center - sum8;
+            if (edge_mag < 0)
+                edge_mag = -edge_mag;
+
+            /* edge_mag above stays on raw luma; dithering below uses gamma-corrected luma. */
+            uint8_t gamma_center = edge_atkinson_gamma_lut[center];
+            int16_t luminance = (int16_t)gamma_center + curr_row[dst_x];
+            if (luminance < 0)
+                luminance = 0;
+            if (luminance > 255)
+                luminance = 255;
+
+            int is_edge = edge_mag > EDGE_ATKINSON_THRESHOLD && gamma_center < EDGE_ATKINSON_MAX_BRIGHTNESS;
+            uint8_t new_pixel = is_edge ? 0 : ((luminance >= black_thresh) ? 255 : 0);
+
+            int should_set_bit = invert ? (new_pixel == 255) : (new_pixel == 0);
+            if (should_set_bit) {
+                int byte_index = row_offset + (dst_x >> 3);
+                int bit_position = 7 - (dst_x & 0x07);
+                binary_data[byte_index] |= (1 << bit_position);
+            }
+
+            /* Atkinson diffusion: 6 neighbors at 1/8 each, remaining 2/8 discarded
+             * (this is what keeps Atkinson crisper/less "muddy" than Floyd-Steinberg) */
+            if (!is_edge) {
+                int16_t error = luminance - new_pixel;
+                if (dst_x < dst_width - 1)
+                    curr_row[dst_x + 1] += error / 8;
+                if (dst_x < dst_width - 2)
+                    curr_row[dst_x + 2] += error / 8;
+                if (dst_x > 0)
+                    next_row1[dst_x - 1] += error / 8;
+                next_row1[dst_x] += error / 8;
+                if (dst_x < dst_width - 1)
+                    next_row1[dst_x + 1] += error / 8;
+                next_row2[dst_x] += error / 8;
+            }
+        }
+
+        /* Rotate rows */
+        int16_t *temp = curr_row;
+        curr_row = next_row1;
+        next_row1 = next_row2;
+        next_row2 = temp;
+        memset(next_row2 - 2, 0, (dst_width + 4) * sizeof(int16_t));
+    }
+
+    Free(error_buffer);
+
+    return 0;
+}
+
+/**
+ * @brief Converts YUV422 to binary using gamma-corrected serpentine Floyd-Steinberg.
+ *
+ * Gamma brightens shadow detail before dithering; scan direction alternates
+ * per row (serpentine) instead of always sweeping left-to-right.
+ *
+ * @param yuv422_data Pointer to the source YUV422 image data.
+ * @param src_width Width of the source image.
+ * @param src_height Height of the source image.
+ * @param binary_data Pointer to the destination binary image buffer.
+ * @param dst_width Width of the destination image.
+ * @param dst_height Height of the destination image.
+ * @param invert Color inversion flag (1: bit=1->white, 0: bit=1->black).
+ * @return 0 on success, negative value on error.
+ */
+static int yuv422_to_gamma_serpentine(const uint8_t *yuv422_data, int src_width, int src_height, uint8_t *binary_data,
+                                      int dst_width, int dst_height, int invert)
+{
+    static uint8_t gamma_lut[256];
+    static bool    gamma_lut_ready = false;
+
+    if (!gamma_lut_ready) {
+        for (int i = 0; i < 256; i++) {
+            float v = powf((float)i / 255.0f, 1.0f / GAMMA_SERPENTINE_GAMMA) * 255.0f;
+            gamma_lut[i] = (uint8_t)(v < 0.0f ? 0.0f : (v > 255.0f ? 255.0f : v));
+        }
+        gamma_lut_ready = true;
+    }
+
+    int binary_stride = (dst_width + 7) / 8;
+    int crop_offset = (src_width - dst_height) / 2; /* Dynamic: (src_width - dst_height) / 2 */
+
+    /* Error rows with 1-pixel padding on both sides (needed for serpentine scan) */
+    int16_t *error_buffer = (int16_t *)Malloc((dst_width + 2) * 2 * sizeof(int16_t));
+    if (!error_buffer) {
+        return -1;
+    }
+
+    int16_t *curr_row = error_buffer + 1;
+    int16_t *next_row = error_buffer + dst_width + 3;
+    memset(error_buffer, 0, (dst_width + 2) * 2 * sizeof(int16_t));
+
+    for (int dst_y = 0; dst_y < dst_height; dst_y++) {
+        int row_offset = dst_y * binary_stride;
+        int direction = (dst_y % 2 == 0) ? 1 : -1;
+        int dst_x = (direction == 1) ? 0 : dst_width - 1;
+
+        for (int count = 0; count < dst_width; count++, dst_x += direction) {
+            int src_x = dst_y + crop_offset;
+            int src_y = src_height - 1 - dst_x;
+
+            if (src_x < 0 || src_x >= src_width || src_y < 0 || src_y >= src_height) {
+                continue;
+            }
+
+            int yuv_index = src_y * src_width * 2 + src_x * 2 + 1;
+            uint8_t gamma_corrected = gamma_lut[yuv422_data[yuv_index]];
+
+            int16_t luminance = (int16_t)gamma_corrected + curr_row[dst_x];
+            if (luminance < 0)
+                luminance = 0;
+            if (luminance > 255)
+                luminance = 255;
+
+            uint8_t new_pixel = (luminance >= GAMMA_SERPENTINE_THRESHOLD) ? 255 : 0;
+            int16_t error = luminance - new_pixel;
+
+            int should_set_bit = invert ? (new_pixel == 255) : (new_pixel == 0);
+            if (should_set_bit) {
+                int byte_index = row_offset + (dst_x >> 3);
+                int bit_position = 7 - (dst_x & 0x07);
+                binary_data[byte_index] |= (1 << bit_position);
+            }
+
+            /* Serpentine Floyd-Steinberg: propagation direction flips every row */
+            if (dst_x + direction >= 0 && dst_x + direction < dst_width)
+                curr_row[dst_x + direction] += (error * 7) / 16;
+            if (dst_y < dst_height - 1) {
+                if (dst_x - direction >= 0 && dst_x - direction < dst_width)
+                    next_row[dst_x - direction] += (error * 3) / 16;
+                next_row[dst_x] += (error * 5) / 16;
+                if (dst_x + direction >= 0 && dst_x + direction < dst_width)
+                    next_row[dst_x + direction] += error / 16;
+            }
+        }
+
+        /* Swap rows */
+        int16_t *temp = curr_row;
+        curr_row = next_row;
+        next_row = temp;
+        memset(next_row - 1, 0, (dst_width + 2) * sizeof(int16_t));
+    }
+
+    Free(error_buffer);
+
+    return 0;
+}
 
 /**
  * @brief Converts YUV422 format image to binary (monochrome) format.
@@ -653,6 +906,14 @@ OPERATE_RET tal_image_format_yuv422_to_binary(TAL_IMAGE_YUV422_TO_BINARY_T *conv
     case TAL_IMAGE_MONO_MTH_JARVIS:
         return yuv422_to_jarvis(conv_cfg->in_buf, conv_cfg->in_width, conv_cfg->in_height, conv_cfg->out_buf,
                                 conv_cfg->out_width, conv_cfg->out_height, conv_cfg->invert_colors);
+
+    case TAL_IMAGE_MONO_MTH_EDGE_ATKINSON:
+        return yuv422_to_edge_atkinson(conv_cfg->in_buf, conv_cfg->in_width, conv_cfg->in_height, conv_cfg->out_buf,
+                                       conv_cfg->out_width, conv_cfg->out_height, conv_cfg->invert_colors);
+
+    case TAL_IMAGE_MONO_MTH_GAMMA_SERPENTINE:
+        return yuv422_to_gamma_serpentine(conv_cfg->in_buf, conv_cfg->in_width, conv_cfg->in_height, conv_cfg->out_buf,
+                                          conv_cfg->out_width, conv_cfg->out_height, conv_cfg->invert_colors);
 
     default:
         return OPRT_COM_ERROR;


### PR DESCRIPTION
## Summary
Follow-up to #677. That PR added `BINARY_METHOD_EDGE_ATKINSON` / `BINARY_METHOD_GAMMA_SERPENTINE` only to tuya_t5_pocket_ai's app-local YUV422->binary conversion code. This PR ports the same two methods into the shared `src/tal_image` component (`TAL_IMAGE_MONO_MTH_EDGE_ATKINSON` / `TAL_IMAGE_MONO_MTH_GAMMA_SERPENTINE`), which is already linked into many other apps (`your_robot_dog`, `your_chat_bot`, `lvgl_games`, `mimiclaw`, etc.) via `tal_image_format_yuv422_to_binary()`, so they're available there too instead of only existing as a one-off app-local copy.

- Edge-locked Atkinson: locks high-contrast edges (raw 3x3 Laplacian magnitude, brightness-gated) to solid black, Atkinson-diffuses the rest.
- Gamma-corrected serpentine Floyd-Steinberg: gamma-brightens shadow detail before dithering (since raw camera luma isn't gamma-corrected and diffusion otherwise preserves the source's true, often darker, average brightness); scan direction alternates per row.
- Implementation mirrors the app-local version exactly, adapted to this file's existing conventions (`Malloc`/`Free` macros, `/* */` comment style).

## Test plan
- [x] `tos.py build` succeeds for T5AI / TUYA_T5AI_POCKET (tuya_t5_pocket_ai links `tal_image`)
- [ ] Reviewer: consider building another `tal_image`-consuming app (e.g. `your_chat_bot`) as a second confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)