### PR TITLE
fix(kconfig): missing endif in ESP32 Kconfig breaks all board builds

### DIFF
--- a/boards/ESP32/Kconfig
+++ b/boards/ESP32/Kconfig
@@ -141,6 +141,7 @@ choice
         bool "XTEINK_X4_PRO (ESP32-S3 e-paper reader)"
         if (BOARD_CHOICE_XTEINK_X4_PRO)
             rsource "./XTEINK_X4_PRO/Kconfig"
+        endif
 
     config BOARD_CHOICE_XTEINK_X4
         bool "XTEINK_X4 (ESP32-C3 e-paper reader)"


### PR DESCRIPTION
boards/ESP32/Kconfig's XTEINK_X4_PRO choice entry (added in #682) is missing the closing endif that every other entry in this choice block has, causing Kconfig parsing to fail with `couldn't parse 'endchoice': no corresponding 'choice'` -- this blocks building   ANY board, not just ESP32 ones. One-line fix, matches the sibling XTEINK_X4 entry's structure.
