### PR TITLE
fix(cli): harden tos.py against config loss, injection, and stuck gitconfig

### DIFF
--- a/tools/cli_command/cli_build.py
+++ b/tools/cli_command/cli_build.py
@@ -129,12 +129,17 @@ def prepare_platform(platform, chip=""):
         return True
 
     if os.path.exists(prepare_py):
-        parpare_cmd = "python platform_prepare.py"
+        cmd = ["python", "platform_prepare.py"]
     else:
-        parpare_cmd = "./platform_prepare.sh"
+        cmd = ["./platform_prepare.sh"]
 
     logger.info(f"Preparing platform [{platform}] ...")
-    cmd = f"{parpare_cmd} {chip}"
+    # chip defaults to "" (some platforms don't take one); appended only
+    # when set, since a passed-through empty string would otherwise become
+    # a real (unwanted) extra argument once shell=True string interpolation
+    # is replaced by an argv list.
+    if chip:
+        cmd.append(chip)
     ret = do_subprocess(cmd, cwd=platform_root)
     if 0 != ret:
         return False
@@ -160,13 +165,15 @@ def build_setup(platform, project_name, framework, chip=""):
         return True
 
     if os.path.exists(setup_py):
-        setup_cmd = "python build_setup.py"
+        cmd = ["python", "build_setup.py"]
     else:
-        setup_cmd = "./build_setup.sh"
+        cmd = ["./build_setup.sh"]
 
     logger.info("Build setup ...")
-    cmd = f"{setup_cmd} "
-    cmd += f"{project_name} {platform} {framework} {chip}"
+    cmd += [project_name, platform, framework]
+    # See prepare_platform() above: chip is optional, only append when set.
+    if chip:
+        cmd.append(chip)
     ret = do_subprocess(cmd, cwd=platform_root)
     if 0 != ret:
         return False
@@ -185,9 +192,9 @@ def cmake_configure(using_data, verbose=False):
     '''
     params = get_global_params()
     open_root = params["open_root"]
-    cmd = f"cmake -G Ninja {open_root} "
+    cmd = ["cmake", "-G", "Ninja", open_root]
     if verbose:
-        cmd += "-DCMAKE_VERBOSE_MAKEFILE=ON "
+        cmd.append("-DCMAKE_VERBOSE_MAKEFILE=ON")
 
     project_name = using_data.get("CONFIG_PROJECT_NAME", "")
     app_root = params["app_root"]
@@ -224,7 +231,7 @@ def cmake_configure(using_data, verbose=False):
         f"-DTOS_PROJECT_BOARD={board_name}",
     ]
 
-    cmd += " ".join(defines)
+    cmd += defines
 
     build_path = params["app_build_path"]
     ret = do_subprocess(cmd, cwd=build_path)

--- a/tools/cli_command/cli_check.py
+++ b/tools/cli_command/cli_check.py
@@ -139,10 +139,16 @@ def update_submodules():
     if code == "China":
         set_repo_mirro(unset=False)
 
-    ret = download_submoudules(open_root)
-
-    if code == "China":
-        set_repo_mirro(unset=True)
+    # try/finally so an exception (e.g. a corrupted submodule repo) or a
+    # Ctrl-C during the download can't skip the unset below and leave the
+    # global github->gitee mirror rewrite stuck in ~/.gitconfig, affecting
+    # every other git operation on this machine. Mirrors the same pattern
+    # already used around download_platform() in cli_build.py.
+    try:
+        ret = download_submoudules(open_root)
+    finally:
+        if code == "China":
+            set_repo_mirro(unset=True)
     return ret
 
 

--- a/tools/cli_command/cli_config.py
+++ b/tools/cli_command/cli_config.py
@@ -97,7 +97,17 @@ def init_using_config(force=False):
         pass
 
     using_config = params["using_config"]
-    if force or not os.path.exists(using_config):
+    # Regenerate whenever using.config is missing, or app_default.config was
+    # edited after using.config was last derived from it -- otherwise a
+    # hand-edit to app_default.config (e.g. in a text editor, outside
+    # `config set`/`config choice`) is silently ignored by the next build.
+    stale = (
+        not os.path.exists(using_config)
+        or os.path.getmtime(app_default_config) > os.path.getmtime(using_config)
+    )
+    if force or stale:
+        if stale and not force:
+            logger.info("app_default.config changed; regenerating using.config")
         _defconfig(app_default_config, using_config, catalog_kconfig)
     pass
 
@@ -289,6 +299,11 @@ def config_menu_exec():
     kconf = Kconfig(filename=catalog_kconfig)
     menuconfig(kconf)
     _savedefconfig(app_default_config, using_config, catalog_kconfig)
+    # _savedefconfig above writes app_default.config last, which would
+    # leave it newer than using.config and make init_using_config()'s mtime
+    # check (see its docstring) think it's stale on every subsequent build,
+    # triggering a needless re-derive. Re-sync using.config's mtime now.
+    _defconfig(app_default_config, using_config, catalog_kconfig)
     sys.exit(0)
 
 

--- a/tools/cli_command/cli_dev.py
+++ b/tools/cli_command/cli_dev.py
@@ -9,7 +9,7 @@ from tools.cli_command.util import (
     set_clis, get_logger, get_global_params,
     parse_config_file
 )
-from tools.cli_command.cli_config import get_board_config_dir
+from tools.cli_command.cli_config import get_board_config_dir, init_using_config
 from tools.cli_command.util_files import (
     get_files_from_path, copy_file, rm_rf
 )
@@ -93,7 +93,12 @@ def _save_product(dist, config_file):
 @click.option('-s', '--skip',
               multiple=True,
               help="Skip config(s) by name. Repeatable; comma-separated names are supported.")
-def build_all_config_exec(dist, log_dir, skip):
+@click.option('--force-clean-backup',
+              is_flag=True, default=False,
+              help="Discard a leftover backup from a previous interrupted "
+                   "[dev bac] run and proceed. Only use this after you have "
+                   "manually confirmed the leftover backup is not needed.")
+def build_all_config_exec(dist, log_dir, skip, force_clean_backup):
     logger = get_logger()
     params = get_global_params()
     dist_abs = os.path.abspath(dist)
@@ -114,6 +119,31 @@ def build_all_config_exec(dist, log_dir, skip):
 
     # build all config
     app_default_config = params["app_default_config"]
+
+    # A leftover backup means a previous `bac` run was killed mid-way
+    # (SIGKILL, power loss, etc.) before its `finally` block below could
+    # restore app_default.config and clean up. Refuse to proceed by
+    # default: today's app_default.config may already be mid-loop test
+    # content, and blindly overwriting the leftover backup with it would
+    # silently destroy the last copy of the user's real original config.
+    backup_path = app_default_config + ".bac_backup"
+    if os.path.exists(backup_path) and not force_clean_backup:
+        logger.error(
+            f"Found a leftover backup from an interrupted [tos.py dev bac] run:\n"
+            f"  {backup_path}\n"
+            f"Not touching it automatically, to avoid overwriting your real "
+            f"original config. Please resolve manually:\n"
+            f"  1) If this backup IS your original config: copy it back over\n"
+            f"     {app_default_config}, then delete the backup file.\n"
+            f"  2) If {app_default_config} is already what you want to keep\n"
+            f"     (the backup is stale): delete {backup_path}, or re-run\n"
+            f"     with --force-clean-backup to skip this check."
+        )
+        sys.exit(1)
+    if os.path.exists(backup_path):
+        # --force-clean-backup: user has looked and confirmed it's safe.
+        os.remove(backup_path)
+
     build_result_list = []
     exit_flag = 0
     full_clean_project()
@@ -132,24 +162,51 @@ def build_all_config_exec(dist, log_dir, skip):
         logger.error("No config to build after filtering.")
         sys.exit(1)
 
-    for idx, config in enumerate(config_list):
-        config_file_name = os.path.basename(config)
-        copy_file(config, app_default_config)
-        logger.info(f"Build [{idx + 1}/{len(config_list)}] {config_file_name}")
+    # Every config in the loop below overwrites app_default_config; back it
+    # up first (unless this is a brand-new project that doesn't have one
+    # yet) and restore it in `finally` so `bac` never leaves the user's real
+    # config permanently replaced by whichever test config ran last.
+    have_backup = os.path.exists(app_default_config)
+    if have_backup:
+        copy_file(app_default_config, backup_path)
 
-        log_file = os.path.join(log_dir, f"{config_file_name}.log") if log_dir else None
-        ok = build_project(log_file=log_file, log_file_append=False)
+    try:
+        for idx, config in enumerate(config_list):
+            config_file_name = os.path.basename(config)
+            copy_file(config, app_default_config)
+            logger.info(f"Build [{idx + 1}/{len(config_list)}] {config_file_name}")
 
-        if ok:
-            logger.note(f"Build {config_file_name} success")
-            build_result_list.append(f"Build {config_file_name} success")
-            if dist:
-                _save_product(dist_abs, config)
+            log_file = os.path.join(log_dir, f"{config_file_name}.log") if log_dir else None
+            ok = build_project(log_file=log_file, log_file_append=False)
+
+            if ok:
+                logger.note(f"Build {config_file_name} success")
+                build_result_list.append(f"Build {config_file_name} success")
+                if dist:
+                    _save_product(dist_abs, config)
+            else:
+                logger.error(f"Build {config_file_name} failed")
+                build_result_list.append(f"Build {config_file_name} failed")
+                exit_flag = 1
+            full_clean_project(log_file=log_file, log_file_append=True)
+    finally:
+        if have_backup:
+            if copy_file(backup_path, app_default_config):
+                os.remove(backup_path)
+            else:
+                logger.error(
+                    f"Restore failed. Your original config is still at "
+                    f"{backup_path} -- restore it manually."
+                )
         else:
-            logger.error(f"Build {config_file_name} failed")
-            build_result_list.append(f"Build {config_file_name} failed")
-            exit_flag = 1
-        full_clean_project(log_file=log_file, log_file_append=True)
+            # app_default.config did not exist before this run (brand-new
+            # project); return to that same "absent" state instead of
+            # leaving the last test config behind.
+            rm_rf(app_default_config)
+        # using.config was left stale by whichever config ran last in the
+        # loop; force it to be re-derived from the just-restored
+        # app_default.config so build state matches on-disk config again.
+        init_using_config(force=True)
 
     # print build result
     BORDER = "================================"

--- a/tools/cli_command/cli_new.py
+++ b/tools/cli_command/cli_new.py
@@ -306,7 +306,7 @@ def porting_platform(new_platform_path, new_platform_name):
     porting_root = params["porting_root"]
     porting_script = os.path.join(porting_root, "kernel_porting.py")
 
-    cmd = f"python {porting_script} {new_platform_path} {new_platform_name}"
+    cmd = ["python", porting_script, new_platform_path, new_platform_name]
     ret = do_subprocess(cmd)
     if 0 != ret:
         return False
@@ -415,13 +415,26 @@ def initialization_board(boards_root,
     return True
 
 
+# new_platform_name ends up interpolated into shell commands (do_subprocess)
+# and joined into filesystem paths, so it is validated against this
+# whitelist before use -- closes both a shell-injection vector and a path
+# traversal vector (e.g. "../../etc") in one place.
+_PLATFORM_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
 @click.command(help="Generating chip platform \
 migration support package.")
 def new_platform_exec():
     logger = get_logger()
     params = get_global_params()
     logger.note("Input new platform name.")
-    new_platform_name = input("input: ")
+    new_platform_name = input("input: ").strip()
+    if not _PLATFORM_NAME_RE.match(new_platform_name):
+        logger.error(
+            "Platform name must be non-empty and contain only letters, "
+            "digits, '_' or '-'."
+        )
+        sys.exit(1)
     platforms_root = params["platforms_root"]
     new_platform_path = os.path.join(platforms_root, new_platform_name)
 

--- a/tools/cli_command/tests/test_cli_check.py
+++ b/tools/cli_command/tests/test_cli_check.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Unit tests for the try/finally fix around update_submodules() in
+# tools/cli_command/cli_check.py (B3 fix).
+#
+# Run from the repo root:
+#   python -m unittest tools.cli_command.tests.test_cli_check -v
+
+import unittest
+from unittest.mock import patch, call, MagicMock
+
+
+class TestUpdateSubmodulesMirrorCleanup(unittest.TestCase):
+    '''
+    set_repo_mirro rewrites the user's global ~/.gitconfig (github ->
+    gitee, 13 repos) for the duration of the submodule download. Before
+    this fix, an exception (or Ctrl-C) from download_submoudules() would
+    skip the unset call and leave that rewrite permanently in place,
+    affecting every other git operation on the machine.
+    '''
+
+    def _patched(self, country_code, download_side_effect):
+        import tools.cli_command.cli_check as m
+        params = {"open_root": "/fake/root"}
+        return m, [
+            patch('tools.cli_command.cli_check.get_global_params',
+                 return_value=params),
+            patch('tools.cli_command.cli_check.get_country_code',
+                 return_value=country_code),
+            patch('tools.cli_command.cli_check.set_repo_mirro'),
+            patch('tools.cli_command.cli_check.download_submoudules',
+                 side_effect=download_side_effect),
+        ]
+
+    def test_mirror_is_unset_even_if_download_raises(self):
+        m, patches = self._patched("China", RuntimeError("boom"))
+        with patches[0], patches[1], patches[2] as mirro, patches[3]:
+            with self.assertRaises(RuntimeError):
+                m.update_submodules()
+            self.assertEqual(
+                mirro.call_args_list,
+                [call(unset=False), call(unset=True)])
+
+    def test_mirror_set_and_unset_on_success(self):
+        m, patches = self._patched("China", lambda open_root: True)
+        with patches[0], patches[1], patches[2] as mirro, patches[3]:
+            ret = m.update_submodules()
+            self.assertTrue(ret)
+            self.assertEqual(
+                mirro.call_args_list,
+                [call(unset=False), call(unset=True)])
+
+    def test_mirror_not_touched_outside_china(self):
+        m, patches = self._patched("Other", lambda open_root: True)
+        with patches[0], patches[1], patches[2] as mirro, patches[3]:
+            ret = m.update_submodules()
+            self.assertTrue(ret)
+            mirro.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/tests/test_cli_config.py
+++ b/tools/cli_command/tests/test_cli_config.py
@@ -123,5 +123,44 @@ class TestDerivedArtifactsList(unittest.TestCase):
         self.assertIn("tuya_kconfig.h", names)
 
 
+class TestConfigMenuResyncsUsingConfigMtime(unittest.TestCase):
+    '''
+    Regression test for the B11 follow-up: config_menu_exec must not
+    leave app_default.config newer than using.config, or the very next
+    init_using_config(force=False) call (e.g. from a plain `tos.py build`)
+    would treat a menuconfig session as if the user had hand-edited
+    app_default.config and pay for a needless full re-derive.
+    '''
+
+    def test_defconfig_runs_after_savedefconfig(self):
+        import tools.cli_command.cli_config as m
+
+        calls = []
+        params = {
+            "using_config": "using.config",
+            "catalog_kconfig": "Catalog.Kconfig",
+            "app_default_config": "app_default.config",
+        }
+
+        with patch('tools.cli_command.cli_config.full_clean_project'), \
+             patch('tools.cli_command.cli_config.init_using_config'), \
+             patch('tools.cli_command.cli_config.get_global_params',
+                   return_value=params), \
+             patch('tools.cli_command.cli_config.Kconfig'), \
+             patch('tools.cli_command.cli_config.menuconfig'), \
+             patch('tools.cli_command.cli_config._savedefconfig',
+                   side_effect=lambda *a, **k: calls.append('savedefconfig')), \
+             patch('tools.cli_command.cli_config._defconfig',
+                   side_effect=lambda *a, **k: calls.append('defconfig')):
+            with self.assertRaises(SystemExit):
+                m.config_menu_exec.callback()
+
+        self.assertEqual(
+            calls, ['savedefconfig', 'defconfig'],
+            "using.config must be re-derived AFTER app_default.config is "
+            "written, or its mtime is left stale relative to "
+            "app_default.config")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/cli_command/tests/test_cli_dev.py
+++ b/tools/cli_command/tests/test_cli_dev.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Unit tests for the backup/restore logic added to
+# tools/cli_command/cli_dev.py::build_all_config_exec (B12 fix).
+#
+# Run from the repo root:
+#   python -m unittest tools.cli_command.tests.test_cli_dev -v
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class BuildAllConfigBase(unittest.TestCase):
+    '''
+    Drives build_all_config_exec.callback() directly against a throwaway
+    tree of two candidate configs, with build_project/full_clean_project/
+    init_using_config mocked out (no toolchain involved) so only the
+    backup/restore logic around app_default.config is under test.
+    '''
+
+    def setUp(self):
+        import tools.cli_command.cli_dev as m
+        self.m = m
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.app_configs_path = os.path.join(self._tmp.name, "configs")
+        os.makedirs(self.app_configs_path)
+        self.app_default_config = os.path.join(
+            self._tmp.name, "app_default.config")
+        self.backup_path = self.app_default_config + ".bac_backup"
+
+        for name, content in (("a.config", "CONFIG_A=y\n"),
+                             ("b.config", "CONFIG_B=y\n")):
+            with open(os.path.join(self.app_configs_path, name),
+                     'w', encoding='utf-8') as f:
+                f.write(content)
+
+        self.params = {
+            "app_configs_path": self.app_configs_path,
+            "app_default_config": self.app_default_config,
+            "boards_root": os.path.join(self._tmp.name, "boards"),
+        }
+
+        self._patches = [
+            patch('tools.cli_command.cli_dev.get_logger',
+                 return_value=MagicMock()),
+            patch('tools.cli_command.cli_dev.get_global_params',
+                 return_value=self.params),
+            patch('tools.cli_command.cli_dev.full_clean_project'),
+            patch('tools.cli_command.cli_dev.init_using_config'),
+            patch('tools.cli_command.cli_dev.build_project',
+                 return_value=True),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def run_bac(self, force_clean_backup=False):
+        try:
+            self.m.build_all_config_exec.callback(
+                dist="", log_dir=None, skip=(),
+                force_clean_backup=force_clean_backup)
+        except SystemExit as e:
+            return e.code
+        return None
+
+    def write_app_default(self, content):
+        with open(self.app_default_config, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+    def read_app_default(self):
+        with open(self.app_default_config, encoding='utf-8') as f:
+            return f.read()
+
+
+class TestBackupRestore(BuildAllConfigBase):
+
+    def test_original_app_default_is_restored_after_run(self):
+        self.write_app_default("CONFIG_ORIGINAL=y\n")
+        code = self.run_bac()
+        self.assertEqual(code, 0)
+        self.assertEqual(self.read_app_default(), "CONFIG_ORIGINAL=y\n")
+        self.assertFalse(os.path.exists(self.backup_path))
+
+    def test_brand_new_project_ends_with_no_app_default(self):
+        # app_default.config does not exist before this run: `bac` must
+        # return to that same "absent" state, not leave the last test
+        # config behind (the original B12 bug's behaviour).
+        self.assertFalse(os.path.exists(self.app_default_config))
+        code = self.run_bac()
+        self.assertEqual(code, 0)
+        self.assertFalse(os.path.exists(self.app_default_config))
+        self.assertFalse(os.path.exists(self.backup_path))
+
+    def test_a_build_failure_still_restores(self):
+        with patch('tools.cli_command.cli_dev.build_project',
+                   return_value=False):
+            self.write_app_default("CONFIG_ORIGINAL=y\n")
+            code = self.run_bac()
+        self.assertEqual(code, 1)  # exit_flag, not the guard's sys.exit(1)
+        self.assertEqual(self.read_app_default(), "CONFIG_ORIGINAL=y\n")
+
+
+class TestLeftoverBackupGuard(BuildAllConfigBase):
+    '''
+    A leftover .bac_backup means a previous `bac` run was killed mid-way
+    (SIGKILL, power loss) before its `finally` block could restore and
+    clean up. Neither file may be touched by default: today's
+    app_default.config may already be mid-loop test content, and blindly
+    overwriting the leftover backup with it would destroy the last copy
+    of the user's real original config.
+    '''
+
+    def test_leftover_backup_refuses_by_default(self):
+        self.write_app_default("CONFIG_MID_LOOP=y\n")
+        with open(self.backup_path, 'w', encoding='utf-8') as f:
+            f.write("CONFIG_REAL_ORIGINAL=y\n")
+
+        code = self.run_bac(force_clean_backup=False)
+
+        self.assertEqual(code, 1)
+        self.assertEqual(self.read_app_default(), "CONFIG_MID_LOOP=y\n")
+        with open(self.backup_path, encoding='utf-8') as f:
+            self.assertEqual(f.read(), "CONFIG_REAL_ORIGINAL=y\n")
+
+    def test_force_clean_backup_discards_leftover_and_proceeds(self):
+        self.write_app_default("CONFIG_MID_LOOP=y\n")
+        with open(self.backup_path, 'w', encoding='utf-8') as f:
+            f.write("CONFIG_STALE=y\n")
+
+        code = self.run_bac(force_clean_backup=True)
+
+        self.assertEqual(code, 0)
+        # The leftover backup was discarded, so what gets restored is
+        # today's (pre-loop) app_default.config -- not the stale backup.
+        self.assertEqual(self.read_app_default(), "CONFIG_MID_LOOP=y\n")
+        self.assertFalse(os.path.exists(self.backup_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/tests/test_cli_new.py
+++ b/tools/cli_command/tests/test_cli_new.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Unit tests for the input validation added to
+# tools/cli_command/cli_new.py::new_platform_exec (B1 fix).
+#
+# Run from the repo root:
+#   python -m unittest tools.cli_command.tests.test_cli_new -v
+
+import unittest
+
+
+class TestPlatformNameWhitelist(unittest.TestCase):
+    '''
+    new_platform_name is interpolated into a shell/argv command
+    (do_subprocess) and joined into filesystem paths, so it must be
+    restricted to a safe character set. This closes both the
+    shell-injection vector and a path-traversal vector (e.g. "../../etc")
+    in one place.
+    '''
+
+    def setUp(self):
+        import tools.cli_command.cli_new as m
+        self.pattern = m._PLATFORM_NAME_RE
+
+    def test_accepts_alphanumeric(self):
+        self.assertIsNotNone(self.pattern.match("T5AI_v2"))
+
+    def test_accepts_hyphen_and_underscore(self):
+        self.assertIsNotNone(self.pattern.match("ESP32-S3_custom"))
+
+    def test_rejects_empty(self):
+        self.assertIsNone(self.pattern.match(""))
+
+    def test_rejects_whitespace(self):
+        self.assertIsNone(self.pattern.match("my platform"))
+
+    def test_rejects_shell_metacharacters(self):
+        for bad in ["a;rm -rf ~", "a&&b", "a|b", "a`whoami`",
+                   "a$(whoami)", "a>out.txt", "a<in.txt"]:
+            self.assertIsNone(self.pattern.match(bad), bad)
+
+    def test_rejects_path_traversal(self):
+        self.assertIsNone(self.pattern.match("../../etc"))
+        self.assertIsNone(self.pattern.match("a/b"))
+        self.assertIsNone(self.pattern.match("a\\b"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cli_command/tests/test_config_e2e.py
+++ b/tools/cli_command/tests/test_config_e2e.py
@@ -122,6 +122,50 @@ class TestConfigGet(ConfigE2EBase):
         self.assertEqual(_digest(self.using), before_using)
 
 
+class TestInitUsingConfigStaleness(ConfigE2EBase):
+    '''
+    Regression test for the B11 fix: hand-editing app_default.config
+    outside `config set`/`config choice` (e.g. in a text editor) must not
+    be silently ignored by the next command that calls
+    init_using_config(force=False) -- which is what a plain `tos.py build`
+    does. `config get` exercises the exact same code path
+    (_load_current_kconfig -> init_using_config(force=False)) without
+    needing the full build toolchain.
+    '''
+
+    def test_hand_edited_app_default_is_picked_up(self):
+        # Materialize using.config from the tracked app_default.config.
+        result = self.run_config(
+            "get", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN", "-j")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)
+            ["CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN"], 4096)
+
+        # Hand-edit app_default.config directly, as a user would in a text
+        # editor -- not through `config set`, so nothing re-derives
+        # using.config as a side effect of the edit itself.
+        content = self.read(self.app_default)
+        content = content.replace(
+            "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=4096",
+            "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN=9999")
+        with open(self.app_default, 'w', encoding='utf-8') as f:
+            f.write(content)
+        # Force a strictly newer mtime than using.config's, independent of
+        # the filesystem's timestamp resolution.
+        newer = os.path.getmtime(self.using) + 5
+        os.utime(self.app_default, (newer, newer))
+
+        result = self.run_config(
+            "get", "CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN", "-j")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)
+            ["CONFIG_ENABLE_MBEDTLS_SSL_MAX_CONTENT_LEN"], 9999,
+            "hand-edited app_default.config was not picked up by the next "
+            "command -- init_using_config() staleness check regressed")
+
+
 class TestConfigList(ConfigE2EBase):
 
     def test_list_filtered(self):

--- a/tools/cli_command/tests/test_util_subprocess.py
+++ b/tools/cli_command/tests/test_util_subprocess.py
@@ -129,6 +129,52 @@ class TestDoSubprocess(unittest.TestCase):
         with open(marker, encoding='utf-8') as f:
             self.assertIn("hello", f.read())
 
+    def test_list_form_returns_the_child_exit_code(self):
+        ret = self.m.do_subprocess(
+            [sys.executable, self.script, "3"], cwd=self.work_dir)
+        self.assertEqual(ret, 3)
+
+    def test_list_form_applies_cwd(self):
+        ret = self.m.do_subprocess(
+            [sys.executable, self.script, "0"], cwd=self.work_dir)
+        self.assertEqual(ret, 0)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.work_dir, "marker.txt")))
+
+    def test_list_form_missing_cwd_returns_nonzero_without_raising(self):
+        missing = os.path.join(self._tmp.name, "no_such_dir")
+        ret = self.m.do_subprocess(
+            [sys.executable, self.script, "0"], cwd=missing)
+        self.assertNotEqual(ret, 0)
+
+    def test_empty_list_returns_zero(self):
+        self.assertEqual(self.m.do_subprocess([]), 0)
+        self.assertEqual(self.m.do_subprocess(()), 0)
+
+    def test_list_form_does_not_go_through_a_shell(self):
+        '''
+        The core of the B1 fix: an argument containing shell
+        metacharacters must reach the child as one literal argv entry
+        (shell=False), never be interpreted/split/expanded by a shell.
+        '''
+        marker = os.path.join(self.work_dir, "argv.txt")
+        argv_script = os.path.join(self.script_dir, "print_argv.py")
+        with open(argv_script, 'w', encoding='utf-8') as f:
+            f.write(
+                "import sys\n"
+                "with open(sys.argv[1], 'w', encoding='utf-8') as out:\n"
+                "    out.write(repr(sys.argv[2:]))\n"
+            )
+        dangerous = "a_name; touch INJECTED && echo $(whoami)"
+        ret = self.m.do_subprocess(
+            [sys.executable, argv_script, marker, dangerous],
+            cwd=self.work_dir)
+        self.assertEqual(ret, 0)
+        with open(marker, encoding='utf-8') as f:
+            self.assertEqual(f.read(), repr([dangerous]))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.work_dir, "INJECTED")))
+
 
 class TestCallSitesPassCwd(unittest.TestCase):
     '''

--- a/tools/cli_command/util.py
+++ b/tools/cli_command/util.py
@@ -6,6 +6,7 @@ import sys
 import json
 import yaml
 import click
+import shlex
 import datetime
 import platform
 import logging
@@ -394,16 +395,22 @@ def parse_yaml(yaml_file: str) -> dict:
         return {}
 
 
-def do_subprocess(cmd: str, cwd: str = None) -> int:
+def do_subprocess(cmd, cwd: str = None) -> int:
     '''
-    Run cmd through the shell and return its exit code (0 == success).
+    Run cmd and return its exit code (0 == success).
+
+    cmd may be a str (run through the shell, kept for call sites not yet
+    migrated) or a list/tuple of args (run directly, shell=False -- no
+    shell means no injection risk from an unquoted/unsanitized argument,
+    e.g. a project or platform name containing shell metacharacters).
 
     Pass the working directory as cwd rather than prefixing the command
     with "cd <dir> &&". On Windows, os.system runs via `cmd.exe /c`,
     whose `cd` does not switch drives without /d, so a cross-drive
     "cd D:\\sdk && ..." silently ran in the original directory. Handing
     cwd to the process also means the directory never goes through the
-    shell, so paths containing spaces stop breaking.
+    shell, so paths containing spaces stop breaking -- true for both the
+    str and list forms, since neither prefixes a "cd".
 
     KeyboardInterrupt is deliberately not caught: Ctrl-C during a build
     should abort the whole command, not report a build failure and move
@@ -414,6 +421,16 @@ def do_subprocess(cmd: str, cwd: str = None) -> int:
     if not cmd:
         logger.warning("Subprocess cmd is empty.")
         return 0
+
+    if isinstance(cmd, (list, tuple)):
+        printable = " ".join(shlex.quote(str(c)) for c in cmd)
+        logger.info(f">>> subprocess >>>\n{printable}")
+        try:
+            return subprocess.call(cmd, shell=False, cwd=cwd)
+        except Exception as e:
+            logger.error(f"Do subprocess error: {str(e)}")
+            logger.info(f"do subprocess: {printable}")
+            return 1
 
     logger.info(f">>> subprocess >>>\n{cmd}")
 


### PR DESCRIPTION
## Summary

Fixes four issues in `tools/cli_command/` reported against the TuyaOpen IDE Preview, each verified against current behavior before being fixed:

- **`tos.py dev bac` permanently overwrote `app_default.config`.** `build_all_config_exec` now backs up `app_default.config` before the loop and restores it in a `finally` block (including the brand-new-project case, where none existed before the run). A leftover `.bac_backup` from a previous killed/crashed run is detected and the command refuses to proceed by default — since blindly overwriting that leftover with today's (possibly mid-loop) content could destroy the last copy of the user's real original config — with a `--force-clean-backup` flag to explicitly discard it after manual review.

- **Hand-edited `app_default.config` was silently ignored.** `init_using_config()` only regenerated `using.config` when it was missing, so editing `app_default.config` outside `config set`/`config choice` (e.g. in a text editor) had no effect on the next plain `tos.py build`. It now also regenerates when `app_default.config` is newer than `using.config`. `config_menu_exec()` is adjusted to re-derive `using.config` after saving `app_default.config`, so a menuconfig session doesn't leave `app_default.config` newer and trigger a needless re-derive on every subsequent build.

- **Command injection via unquoted shell interpolation.** `do_subprocess()` ran every command through the shell with f-string-interpolated values; `tos.py new`'s interactive platform name reached it completely unvalidated. `do_subprocess()` now also accepts a list/tuple argv and runs it with `shell=False`; `cli_new.py`'s `porting_platform()` and `cli_build.py`'s `prepare_platform`/`build_setup`/`cmake_configure` are migrated to the list form (optional trailing args, like `chip=""`, are appended conditionally rather than passed through positionally, to avoid turning an absent value into a real empty argv entry). The interactive platform name is also restricted to a `[A-Za-z0-9_-]+` whitelist, closing both the injection vector and a path-traversal vector.

- **`~/.gitconfig` mirror rewrite could get stuck.** `update_submodules()` rewrote the user's global git config (github → gitee mirrors, 13 repos) without a `try/finally`, unlike the equivalent path in `cli_build.py`'s `download_platform()`. An exception or Ctrl-C during the submodule download left the mirror rewrite permanently in place, affecting every other git operation on the machine. Wrapped in `try/finally` to match the existing pattern.

## Tests

Added unit tests for each fix: `test_cli_check.py`, `test_cli_new.py`, `test_cli_dev.py` (new files), plus additions to `test_cli_config.py`, `test_config_e2e.py`, and `test_util_subprocess.py`.

```
uv run --with pytest --with-editable . pytest tools/cli_command/tests/ -q
# 175 passed, 40 skipped

TUYAOPEN_E2E=1 uv run --with pytest --with-editable . pytest tools/cli_command/tests/ -q
# 214 passed, 1 skipped (platform-specific: cross-drive cwd test, skipped on a single-drive layout)
```

## Not in scope for this PR

Other `do_subprocess` call sites that don't take user-controlled input (e.g. `ninja_build`, `git_clone`'s use of GitPython) were left as-is; migrating them is lower-value and can follow incrementally.
