### PR TITLE
refactor(siwx917): follow the platform's tkl_ namespace cleanup

### DIFF
--- a/boards/SiWx917/common/audio/tdd_audio_no_codec.c
+++ b/boards/SiWx917/common/audio/tdd_audio_no_codec.c
@@ -11,6 +11,7 @@
 #include "tal_api.h"
 
 #include "tkl_i2s.h"
+#include "sl_tuya_i2s.h"
 
 /***********************************************************
 ************************macro define************************
@@ -148,7 +149,7 @@ static void si91x_i2s_switch_to_rx(SI91X_I2S_HANDLE_T *hdl)
 
     tkl_i2s_send_stop(hdl->i2s_id);
     tkl_i2s_recv_stop(hdl->i2s_id);
-    tkl_i2s_recv_streaming(hdl->i2s_id, si91x_i2s_buffer_ready_callback, hdl);
+    sl_tuya_i2s_recv_streaming(hdl->i2s_id, si91x_i2s_buffer_ready_callback, hdl);
     PR_NOTICE("I2S mode rx");
 }
 
@@ -175,7 +176,7 @@ static void si91x_i2s_read_task(void *args)
 
     while (1) {
         if (hdl->i2s_mode == I2S_MODE_TX) {
-            if (tkl_i2s_send_inprogress(hdl->i2s_id)) {
+            if (sl_tuya_i2s_send_inprogress(hdl->i2s_id)) {
                 /* Short poll only: SEND_COMPLETE runs in ISR, cannot post semaphore */
                 tal_system_sleep(I2S_TX_POLL_MS);
                 continue;
@@ -291,8 +292,8 @@ static OPERATE_RET __tdd_audio_no_codec_open(TDD_AUDIO_HANDLE_T handle, TDL_AUDI
     }
 
     memset(hdl->rx_buff.buf, 0, sizeof(hdl->rx_buff.buf));
-    tkl_i2s_set_streaming_config(hdl->i2s_id, hdl->rx_buff.buf, I2S_RX_BUFF_FRAME / 2);
-    tkl_i2s_recv_streaming(hdl->i2s_id, si91x_i2s_buffer_ready_callback, hdl);
+    sl_tuya_i2s_set_streaming_config(hdl->i2s_id, hdl->rx_buff.buf, I2S_RX_BUFF_FRAME / 2);
+    sl_tuya_i2s_recv_streaming(hdl->i2s_id, si91x_i2s_buffer_ready_callback, hdl);
 
     TUYA_CALL_ERR_LOG(tal_sw_timer_create(si91x_i2s_audio_player_start, (void *)hdl, &hdl->player_timer_id));
 

--- a/boards/SiWx917/common/display/tdd_display_custom.c
+++ b/boards/SiWx917/common/display/tdd_display_custom.c
@@ -4,7 +4,7 @@
 #include "tdl_display_manage.h"
 #include "tdl_display_driver.h"
 #include "tdd_display_custom.h"
-#include "tkl_display.h"
+#include "sl_tuya_display.h"
 
 static OPERATE_RET __tdl_display_custom_open(TDD_DISP_DEV_HANDLE_T device)
 {
@@ -12,7 +12,7 @@ static OPERATE_RET __tdl_display_custom_open(TDD_DISP_DEV_HANDLE_T device)
         return OPRT_INVALID_PARM;
     }
 
-    tkl_display_init();
+    sl_tuya_display_init();
 
     return OPRT_OK;
 }
@@ -25,7 +25,7 @@ static OPERATE_RET __tdl_display_custom_flush(TDD_DISP_DEV_HANDLE_T device, TDL_
         return OPRT_INVALID_PARM;
     }
 
-    tkl_display_flush(frame_buff->width, frame_buff->height, frame_buff->frame, frame_buff->len);
+    sl_tuya_display_flush(frame_buff->width, frame_buff->height, frame_buff->frame, frame_buff->len);
 
     return rt;
 }


### PR DESCRIPTION
The SiWx917 platform was exposing two platform-private APIs under the tkl_ namespace, and these two board drivers were their only consumers:

  tkl_display_init/flush        -> sl_tuya_display_init/flush
  tkl_i2s_*_streaming,          -> sl_tuya_i2s_*
  tkl_i2s_send_inprogress

The display pair was the worse of the two: it lived in a header named tkl_display.h, the filename the canonical 16-function tkl_disp_* interface owns, so the platform looked like it implemented the display TKL when it implemented none of it. The i2s streaming calls are a genuine platform extension for the DMA receive path, but they are SiWx917-only - neither T5AI nor LINUX has them - so they do not belong in tkl_i2s.h either.

Both now come from platform-private headers (sl_tuya_display.h, sl_tuya_i2s.h), which lets the platform keep tkl_display.h absent and tkl_i2s.h a faithful copy of the canonical header.

Requires tuya/TuyaOpen-SiliconLabs PR "refactor(tkl): conform the adapter surface to the canonical contract". Do not merge before it: the renamed symbols do not exist until that lands, and platform/platform_config.yaml still pins SiWx917 at 1995b489, so this branch will not build on its own. The pin bump belongs in this PR once that sha is known.

tdd_audio_no_codec.c was compile- and link-verified: tos.py build for your_chat_bot on BRD2605A (SIWG917M111MGTBA) succeeded and its object carries the new sl_tuya_i2s_* references. tdd_display_custom.c was not - both BRD2605A and SIWX917_AI_DEV_KIT have CONFIG_ENABLE_DISPLAY off, so it does not compile in any current configuration; the change there is the include name plus two call names.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
