### PR TITLE
fix(esp32-audio): make the AFE voice front end optional, and stop feeding it zero-length frames

### DIFF
--- a/boards/ESP32/common/audio/tdd_audio_8311_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_8311_codec.c
@@ -360,11 +360,11 @@ static void esp32_i2s_8311_read_task(void *args)
             continue;
         }
 
-        int bytes_read = 0;
+        /* From the read, not from mic_cb: a NULL cb used to feed the AFE 0. */
+        int bytes_read = data_len * sizeof(int16_t);
 
         if (hdl->mic_cb) {
             // Call the callback function with the read data
-            bytes_read = data_len * sizeof(int16_t);
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, bytes_read);
         }
 

--- a/boards/ESP32/common/audio/tdd_audio_8311_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_8311_codec.c
@@ -368,7 +368,9 @@ static void esp32_i2s_8311_read_task(void *args)
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, bytes_read);
         }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
         auio_afe_processor_feed(hdl->data_buf, bytes_read);
+#endif
 
         tal_system_sleep(I2S_READ_TIME_MS);
     }
@@ -411,11 +413,14 @@ static OPERATE_RET __tdd_audio_esp_i2s_8311_open(TDD_AUDIO_HANDLE_T handle, TDL_
         return OPRT_COM_ERROR;
     }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
     rt = audio_afe_processor_init();
-    if(rt != OPRT_OK) {
-        PR_ERR("audio_afe_processor_init err:%d",  rt);
-        return rt;
+    if (rt != OPRT_OK) {
+        /* Optional stage: losing it must not take the audio device down. */
+        PR_ERR("audio_afe_processor_init err:%d", rt);
+        rt = OPRT_OK;
     }
+#endif
 
     const THREAD_CFG_T thread_cfg = {
         .thrdname = "esp32_i2s_8311_read",

--- a/boards/ESP32/common/audio/tdd_audio_atk_no_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_atk_no_codec.c
@@ -258,10 +258,10 @@ static void atk_no_codec_read_task(void *args)
             continue;
         }
 
-        int bytes_read = 0;
+        /* From the read, not from mic_cb: a NULL cb used to feed the AFE 0. */
+        int bytes_read = data_len * sizeof(int16_t);
         if (hdl->mic_cb) {
             // Call the callback function with the read data
-            bytes_read = data_len * sizeof(int16_t);
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, bytes_read);
         }
 

--- a/boards/ESP32/common/audio/tdd_audio_atk_no_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_atk_no_codec.c
@@ -265,7 +265,9 @@ static void atk_no_codec_read_task(void *args)
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, bytes_read);
         }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
         auio_afe_processor_feed(hdl->data_buf, bytes_read);
+#endif
 
         tal_system_sleep(I2S_READ_TIME_MS);
     }
@@ -304,11 +306,14 @@ static OPERATE_RET __tdd_atk_no_codec_open(TDD_AUDIO_HANDLE_T handle, TDL_AUDIO_
         return OPRT_COM_ERROR;
     }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
     rt = audio_afe_processor_init();
-    if(rt != OPRT_OK) {
-        PR_ERR("audio_afe_processor_init err:%d",  rt);
-        return rt;
+    if (rt != OPRT_OK) {
+        /* Optional stage: losing it must not take the audio device down. */
+        PR_ERR("audio_afe_processor_init err:%d", rt);
+        rt = OPRT_OK;
     }
+#endif
 
     const THREAD_CFG_T thread_cfg = {
         .thrdname = "atk_no_codec_read",

--- a/boards/ESP32/common/audio/tdd_audio_es8388_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_es8388_codec.c
@@ -228,7 +228,9 @@ static void esp32_i2s_es8388_read_task(void *args)
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, data_len);
         }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
         auio_afe_processor_feed(hdl->data_buf, (uint32_t)data_len);
+#endif
 
         tal_system_sleep(I2S_READ_TIME_MS);
     }
@@ -267,11 +269,14 @@ static OPERATE_RET __tdd_audio_esp_i2s_es8388_open(TDD_AUDIO_HANDLE_T handle, TD
         return OPRT_COM_ERROR;
     }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
     rt = audio_afe_processor_init();
-    if(rt != OPRT_OK) {
-        PR_ERR("audio_afe_processor_init err:%d",  rt);
-        return rt;
+    if (rt != OPRT_OK) {
+        /* Optional stage: losing it must not take the audio device down. */
+        PR_ERR("audio_afe_processor_init err:%d", rt);
+        rt = OPRT_OK;
     }
+#endif
 
     const THREAD_CFG_T thread_cfg = {
         .thrdname = "esp32_i2s_es8388_read",

--- a/boards/ESP32/common/audio/tdd_audio_es8389_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_es8389_codec.c
@@ -238,7 +238,9 @@ static void esp32_i2s_es8389_read_task(void *args)
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, data_len);
         }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
         auio_afe_processor_feed(hdl->data_buf, data_len);
+#endif
 
         tal_system_sleep(I2S_READ_TIME_MS);
     }
@@ -277,11 +279,14 @@ static OPERATE_RET __tdd_audio_esp_i2s_es8389_open(TDD_AUDIO_HANDLE_T handle, TD
         return OPRT_COM_ERROR;
     }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
     rt = audio_afe_processor_init();
-    if(rt != OPRT_OK) {
-        PR_ERR("audio_afe_processor_init err:%d",  rt);
-        return rt;
+    if (rt != OPRT_OK) {
+        /* Optional stage: losing it must not take the audio device down. */
+        PR_ERR("audio_afe_processor_init err:%d", rt);
+        rt = OPRT_OK;
     }
+#endif
 
     const THREAD_CFG_T thread_cfg = {
         .thrdname = "esp32_i2s_es8389_read",

--- a/boards/ESP32/common/audio/tdd_audio_no_codec.c
+++ b/boards/ESP32/common/audio/tdd_audio_no_codec.c
@@ -96,7 +96,9 @@ static void esp32_i2s_read_task(void *args)
                         samples * sizeof(int16_t));
         }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
         auio_afe_processor_feed(hdl->data_buf, samples * sizeof(int16_t));
+#endif
 
         tal_system_sleep(I2S_READ_TIME_MS);
     }
@@ -156,11 +158,14 @@ static OPERATE_RET __tdd_audio_no_codec_open(TDD_AUDIO_HANDLE_T handle, TDL_AUDI
         return OPRT_COM_ERROR;
     }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
     rt = audio_afe_processor_init();
-    if(rt != OPRT_OK) {
-        PR_ERR("audio_afe_processor_init err:%d",  rt);
-        return rt;
+    if (rt != OPRT_OK) {
+        /* Optional stage: losing it must not take the audio device down. */
+        PR_ERR("audio_afe_processor_init err:%d", rt);
+        rt = OPRT_OK;
     }
+#endif
 
     const THREAD_CFG_T thread_cfg = {
         .thrdname = "esp32_i2s_read",

--- a/boards/ESP32/common/audio/tdd_audio_pdm_mic.c
+++ b/boards/ESP32/common/audio/tdd_audio_pdm_mic.c
@@ -76,7 +76,9 @@ static void __pdm_mic_read_task(void *args)
             hdl->mic_cb(TDL_AUDIO_FRAME_FORMAT_PCM, TDL_AUDIO_STATUS_RECEIVING, hdl->data_buf, bytes_read);
         }
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
         auio_afe_processor_feed(hdl->data_buf, bytes_read);
+#endif
     }
 }
 
@@ -124,11 +126,14 @@ static OPERATE_RET __tdd_audio_pdm_mic_open(TDD_AUDIO_HANDLE_T handle, TDL_AUDIO
     TUYA_CHECK_NULL_RETURN(hdl->data_buf, OPRT_MALLOC_FAILED);
     memset(hdl->data_buf, 0, hdl->data_buf_len);
 
+#if defined(ENABLE_AUDIO_AFE) && (ENABLE_AUDIO_AFE == 1)
     rt = audio_afe_processor_init();
     if (rt != OPRT_OK) {
+        /* Optional stage: losing it must not take the audio device down. */
         PR_ERR("audio_afe_processor_init err:%d", rt);
-        return rt;
+        rt = OPRT_OK;
     }
+#endif
 
     const THREAD_CFG_T thread_cfg = {
         .thrdname   = "pdm_mic_read",

--- a/src/peripherals/audio_codecs/Kconfig
+++ b/src/peripherals/audio_codecs/Kconfig
@@ -16,6 +16,14 @@ if (ENABLE_AUDIO_CODECS)
         bool "audio support AEC"
         default n
 
+    config ENABLE_AUDIO_AFE
+        bool "audio support AFE (ESP32: noise suppression + VAD + wake word)"
+        default y
+        ---help---
+            ESP-SR front end (noise suppression + VAD + wake word), started from
+            tdl_audio_open(). Costs internal RAM; its only consumers are the VAD
+            and KWS adapters. Turn off for playback-only products.
+
     config ENABLE_AUDIO_ALSA
         bool "enable ALSA audio support"
         default n


### PR DESCRIPTION
Two bugs in the ESP32 board audio layer, found bringing up a **playback-only** product (a desk timer that just beeps) on `WAVESHARE_ESP32S3_Touch_AMOLED_1.8`.

## 1. The AFE voice front end is mandatory

All six ESP32 audio drivers call `audio_afe_processor_init()` unconditionally from `tdl_audio_open()`, bringing up ESP-SR's full front end — WakeNet keyword model, NSNet noise-suppression model, and two pinned FreeRTOS tasks (8 KB + 4 KB stacks). Its only consumers are the VAD and KWS TKL adapters, and there is no way to opt out: no Kconfig gates it, `audio_afe.c` has no deinit, and each driver's `close()` is a no-op.

The internal-RAM cost breaks products. Opening the codec at boot alongside Wi-Fi starved **both** provisioning paths:

```
BLE_INIT: Malloc failed -> esp_bt_controller_init -4
ap_netcfg.c: tal_malloc(...) null -> netcfg type 0x1 is not regist
```

Deferring the open until the tone had to play only moved the failure — by then Wi-Fi is in steady state and the I2S DMA descriptors cannot be allocated:

```
i2s_alloc_dma_desc: allocate DMA buffer failed -> ESP_ERROR_CHECK -> abort()
```

Both timings failing is what says this is a total budget problem, not an ordering one. Both paths came up and the tone played only once AFE init was skipped.

Flash cost, clean builds on that board:

| | app binary | `esp_afe_*` symbols |
|---|---|---|
| `ENABLE_AUDIO_AFE=y` | 2,037,136 | present |
| `ENABLE_AUDIO_AFE=n` | 1,664,864 | absent |

## 2. `mic_cb == NULL` feeds the AFE a zero length, ~100×/second

`tdl_audio_open(hdl, NULL)` is the documented playback-only usage. In `tdd_audio_8311_codec.c` and `tdd_audio_atk_no_codec.c`, `bytes_read` is declared outside the `if (hdl->mic_cb)` block and assigned inside, then fed to the AFE unconditionally — so with no mic callback the length stays 0 and `auio_afe_processor_feed()` rejects it with `param is err`. The read task loops every 10 ms: **1.8 MB of error output in 25 seconds**, which also corrupted an unrelated banner on the same UART.

The other four drivers derive the length from the read itself and are unaffected — 2 files, not 6.

## What this PR does

**Commit 1** adds `ENABLE_AUDIO_AFE` next to the existing `ENABLE_AUDIO_AEC` and guards the `init` and `feed` calls in all six drivers. **Defaults to `y`, so nothing changes for anyone who does not opt out.** Also stops an AFE init failure from failing the whole `open()`.

**Commit 2** hoists the `bytes_read` assignment out of the `if` in the two affected drivers.

Verified with clean builds both ways (table above). On hardware with AFE skipped, the BT controller came up with a MAC, the SoftAP broadcast, and the tone played through the ES8311 without aborting — the first time all three held at once.

## Notes for the reviewer

- **Default `y` vs `n`.** I kept `y` so this is a no-op for existing users, but the honest default is arguably `n`: the real consumers are VAD and KWS, and `ENABLE_VAD` already exists in `tools/porting/template/Kconfig` (default `n`) while no board selects it. Keying AFE init off VAD/KWS instead of a new symbol would be cleaner — that call is yours.
- **Stale config on incremental builds.** Kconfig is not re-merged incrementally, so the first build after pulling sees the option as unset (AFE off) until reconfigured. Every `#if defined(X) && (X == 1)` flag in the tree behaves this way, but it bites harder for a `default y` one.
- `srmodels.bin` (~284 KB) is still built and flashed even with AFE off. Out of scope here, but it looks like the same kind of unconditional cost.
