### PR TITLE
fix(cli): don't crash tos.py monitor/flash on an unbuilt project

### DIFF
--- a/tools/cli_command/cli_flash.py
+++ b/tools/cli_command/cli_flash.py
@@ -15,6 +15,7 @@ from tools.cli_command.util import (
 )
 from tools.cli_command.util_tyutool import ensure_tyutool
 from tools.cli_command.cli_build import download_platform
+from tools.cli_command.cli_config import init_using_config
 
 
 _PROGRESS_RE = re.compile(r'^\[progress\]\s*(\d+)%\s*$')
@@ -169,12 +170,12 @@ def check_bin_file(using_data) -> bool:
     params = get_global_params()
 
     bin_path = params["app_bin_path"]
-    project_name = using_data["CONFIG_PROJECT_NAME"]
-    project_ver = using_data["CONFIG_PROJECT_VERSION"]
+    project_name = using_data.get("CONFIG_PROJECT_NAME", "")
+    project_ver = using_data.get("CONFIG_PROJECT_VERSION", "")
     bin_file = os.path.join(
         bin_path, f"{project_name}_QIO_{project_ver}.bin")
 
-    if not os.path.isfile(bin_file):
+    if not project_name or not project_ver or not os.path.isfile(bin_file):
         logger.error("Not found bin file, please use [tos.py build].")
         return False
     return True
@@ -254,8 +255,10 @@ def get_configure_baudrate(using_data, key, baudrate: int) -> int:
     logger = get_logger()
     params = get_global_params()
 
-    platform = using_data["CONFIG_PLATFORM_CHOICE"]
-    board = using_data["CONFIG_BOARD_CHOICE"]
+    platform = using_data.get("CONFIG_PLATFORM_CHOICE", "")
+    board = using_data.get("CONFIG_BOARD_CHOICE", "")
+    if not platform or not board:
+        return baudrate
     boards_root = params["boards_root"]
     config_file = os.path.join(boards_root, platform,
                                board, "tyutool.cfg")
@@ -294,7 +297,7 @@ def get_flash_cmd(using_data,
         cmd = f"{cmd} --debug"
     cmd = f"{cmd} write"
 
-    platform = using_data["CONFIG_PLATFORM_CHOICE"]
+    platform = using_data.get("CONFIG_PLATFORM_CHOICE", "")
     chip = using_data.get("CONFIG_CHIP_CHOICE", "")
     device = _normalize_device(chip if chip else platform)
     cmd = f"{cmd} -d {device}"
@@ -332,11 +335,19 @@ def cli(debug, port, baud):
     logger = get_logger()
     check_proj_dir()
 
+    # Derive using.config from app_default.config (same as `tos.py build`)
+    # so an unbuilt project fails with the friendly "please use tos.py
+    # build" message below instead of a KeyError on a missing config key.
+    init_using_config(force=False)
     params = get_global_params()
     using_config = params["using_config"]
     using_data = parse_config_file(using_config)
 
     if not check_bin_file(using_data):
+        sys.exit(1)
+
+    if not using_data.get("CONFIG_PLATFORM_CHOICE", ""):
+        logger.error("Not found platform, please use [tos.py config].")
         sys.exit(1)
 
     bridge_result = _try_platform_flash(using_data, debug, port, baud)

--- a/tools/cli_command/cli_monitor.py
+++ b/tools/cli_command/cli_monitor.py
@@ -19,6 +19,7 @@ from tools.cli_command.util import (
     get_logger, get_global_params, check_proj_dir,
     parse_config_file,
 )
+from tools.cli_command.cli_config import init_using_config
 from tools.cli_command.cli_flash import (
     get_configure_baudrate
 )
@@ -209,6 +210,10 @@ def cli(port, baud, log):
     logger.info("Monitor: Press Ctrl+] to quit.")
     check_proj_dir()
 
+    # Derive using.config from app_default.config (same as `tos.py build`)
+    # so the correct board's baudrate is known even if the project has
+    # never been built yet.
+    init_using_config(force=False)
     params = get_global_params()
     using_config = params["using_config"]
     using_data = parse_config_file(using_config)


### PR DESCRIPTION
## Summary
- `tos.py monitor` and `tos.py flash` read `using.config` via plain dict-subscript (`using_data["CONFIG_PLATFORM_CHOICE"]`, etc.). When the project has never been built, `using.config` doesn't exist yet, `parse_config_file()` silently returns `{}`, and the subscript throws an unhandled `KeyError` (raw Python traceback) instead of a usable message.
- `monitor` now calls `init_using_config(force=False)` before reading the config (same call `build` already makes), so the correct per-board baudrate is derived from `app_default.config` even without a prior build.
- `flash` gets the same `init_using_config()` call, so an unbuilt project now hits the existing `"Not found bin file, please use [tos.py build]."` message instead of crashing. Also added a friendly guard + `.get()` fallback for `CONFIG_PLATFORM_CHOICE` in `get_flash_cmd()` — the one remaining spot that could still `KeyError` (e.g. a hand-edited/corrupted `using.config`).
- Hardened `get_configure_baudrate()` / `check_bin_file()` to use `.get()` with graceful fallback instead of hard subscripting, since they're shared helpers reachable from more than one call site.

## Test plan
- [x] `tos.py monitor` on an unbuilt project (no `using.config`) now derives the correct board baudrate instead of crashing with `KeyError: 'CONFIG_PLATFORM_CHOICE'`
- [x] `tos.py flash` on an unbuilt project (no `using.config`, no bin) now prints `Not found bin file, please use [tos.py build].` instead of crashing
- [x] `tos.py flash` with `using.config` present but missing `CONFIG_PLATFORM_CHOICE` now prints `Not found platform, please use [tos.py config].` instead of crashing
- [x] `tos.py flash` where only `using.config` was regenerated but the bin file still exists successfully proceeds to the flash step (self-heals)
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)