### PR TITLE
fix(ai-input): guard __ai_crt_ringbuf against NULL session context

### DIFF
--- a/src/tuya_ai_service/svc_ai_agent/src/tuya_ai_input.c
+++ b/src/tuya_ai_service/svc_ai_agent/src/tuya_ai_input.c
@@ -132,6 +132,9 @@ STATIC TUYA_RINGBUFF_T __ai_crt_ringbuf(CHAR_T *scode)
 {
     OPERATE_RET rt = OPRT_OK;
     AI_INPUT_SESSION_CTX_T *sctx = __ai_get_sctx(scode);
+    if (sctx == NULL) {
+        return NULL;
+    }
     if (sctx && sctx->ringbuf) {
         return sctx->ringbuf;
     }


### PR DESCRIPTION
## Problem

`__ai_crt_ringbuf()` dereferences the session context it just looked up without
checking it for NULL:

```c
STATIC TUYA_RINGBUFF_T __ai_crt_ringbuf(CHAR_T *scode)
{
    OPERATE_RET rt = OPRT_OK;
    AI_INPUT_SESSION_CTX_T *sctx = __ai_get_sctx(scode);
    if (sctx && sctx->ringbuf) {          /* the read is guarded ... */
        return sctx->ringbuf;
    }

    tal_mutex_lock(ai_input_ctx.mutex);
    rt = tuya_ring_buff_create(AI_INPUT_RINGBUF_SIZE, ..., &sctx->ringbuf);
                                          /* ... the write is not */
```

`__ai_get_sctx()` returns NULL when no session exists for `scode`. The existing
`if (sctx && sctx->ringbuf)` only protects the fast path: when `sctx == NULL`,
execution falls through to `&sctx->ringbuf`, which is the absolute address
`offsetof(AI_INPUT_SESSION_CTX_T, ringbuf)`. `tuya_ring_buff_create()` then
*writes* the newly created handle to that address and the MPU faults.

## Symptom

MemFault, black screen, device reset:

```
40 MMFAR x 0x4c      41 BFAR x 0x4c     42 CFSR x 0x82
MemFault
Fault on thread record_task
```

`record_task` is the thread carrying the audio `output_cb`, which is the path
that reaches `__ai_crt_ringbuf()`. The faulting address matches the struct
layout exactly:

| field | offset |
|---|---|
| `CHAR_T scode[AI_SOLUTION_CODE_LEN]` (64) | `0x00` |
| `BOOL_T queue_sync` | `0x40` |
| `QUEUE_HANDLE queue` | `0x44` |
| `UINT32_T lazy_input` | `0x48` |
| `TUYA_RINGBUFF_T ringbuf` | **`0x4C`** |

`MMFAR` and `BFAR` both read `0x4c` — `offsetof(..., ringbuf)` off a NULL base
pointer.

## Reproduction

On a T5AI board running an AI chat application: provision the device, enter the
chat page, and long-press PTT *before* the cloud session has reached RUNNING —
that is, before any session has been established since boot. The window is
widest immediately after provisioning, which is also when a user is most likely
to press and start talking. The trigger is pressing too *early*, not too fast.

Reproduced three times out of three on a Waveshare T5AI-Touch-AMOLED-1.75, with
the same fault signature each time.

## Fix

Return NULL when there is no session context. `__ai_ringbuf_write()`, the only
caller, already handles a NULL return, so nothing changes for paths that
previously worked: the audio frame is dropped and the next press behaves
normally once the session exists.

Note the `sctx &&` in the following `if` is redundant now that `sctx` cannot be
NULL past the new guard. Left in place to keep the diff minimal — happy to drop
it if you'd rather.
