### PR TITLE
fix(camera): bring the sensor up once, and let close mean stop

### DIFF
--- a/apps/tuya_cloud/camera_demo/src/tuya_ipc_demo.c
+++ b/apps/tuya_cloud/camera_demo/src/tuya_ipc_demo.c
@@ -951,11 +951,9 @@ static OPERATE_RET __demo_open_camera(void)
 static void __demo_close_camera(void)
 {
     if (s_cam != NULL) {
+        /* close() now stops the DVP; the tkl_dvp_deinit that used to be needed
+         * here forced a full bring-up, and with it a fresh frame pool. */
         (void) tdl_camera_dev_close(s_cam);
-        /* tdl/tdd camera close is NOT_SUPPORTED, so DVP DMA (chan 8) leaks and
-         * reopen fails with "malloc dma fail / chan has been allocated".
-         * Release DVP directly here to fix reopen after APP reconnect. */
-        (void) tkl_dvp_deinit();
         s_cam = NULL;
     }
 }

--- a/src/peripherals/camera/tdd_camera/src/dvp/tdd_camera_dvp.c
+++ b/src/peripherals/camera/tdd_camera/src/dvp/tdd_camera_dvp.c
@@ -30,6 +30,7 @@ typedef struct {
     TDD_DVP_SR_CFG_T          sensor;
     TDD_DVP_SR_INTFS_T        intfs;
     TUYA_DVP_CFG_T            dvp_cfg;
+    bool                      is_inited;
 }CAMERA_DVP_DEV_T;
 
 /***********************************************************
@@ -154,6 +155,7 @@ static OPERATE_RET __tdd_camera_dvp_init(CAMERA_DVP_DEV_T *dev, TDD_CAMERA_OPEN_
     memcpy(&dev->dvp_cfg.encoded_quality, &cfg->encoded_quality, sizeof(TUYA_DVP_ENCODED_QUALITY));
 
     TUYA_CALL_ERR_RETURN(tkl_dvp_init(&dev->dvp_cfg));
+    tkl_dvp_stop(); /* output is open()'s to enable */
 
     return OPRT_OK;
 }
@@ -177,6 +179,12 @@ static OPERATE_RET __tdd_camera_dvp_open(TDD_CAMERA_DEV_HANDLE_T device, TDD_CAM
 
     sg_dvp_dev = dvp_dev;
     p_usr_cfg  = &(dvp_dev->sensor.usr_cfg);
+
+    /* Power, I2C, reset and the sensor's registers are board state, not session
+     * state: bring them up once and let open/close be start/stop. */
+    if(dvp_dev->is_inited) {
+        return tkl_dvp_start();
+    }
 
     if(p_usr_cfg->i2c.port < TUYA_I2C_NUM_MAX) {
         TUYA_CALL_ERR_RETURN(tdd_dvp_i2c_init(&p_usr_cfg->i2c));
@@ -203,7 +211,9 @@ static OPERATE_RET __tdd_camera_dvp_open(TDD_CAMERA_DEV_HANDLE_T device, TDD_CAM
         TUYA_CALL_ERR_RETURN(dvp_dev->intfs.set_ppi(&p_usr_cfg->i2c, ppi, cfg->fps, dvp_dev->intfs.arg));
     }
 
-    return rt;
+    dvp_dev->is_inited = true;
+
+    return tkl_dvp_start();
 }
 
 /**
@@ -213,7 +223,11 @@ static OPERATE_RET __tdd_camera_dvp_open(TDD_CAMERA_DEV_HANDLE_T device, TDD_CAM
  */
 static OPERATE_RET __tdd_camera_dvp_close(TDD_CAMERA_DEV_HANDLE_T device)
 {
-    return OPRT_NOT_SUPPORTED;
+    if(NULL == device) {
+        return OPRT_INVALID_PARM;
+    }
+    /* Stop, not teardown - tkl_dvp_deinit belongs to shutting the board down. */
+    return tkl_dvp_stop();
 }
 
 /**

--- a/src/peripherals/camera/tdl_camera/src/tdl_camera_manage.c
+++ b/src/peripherals/camera/tdl_camera/src/tdl_camera_manage.c
@@ -56,6 +56,10 @@ typedef struct {
 
     struct tuya_list_head       raw_frame_node_list;
     struct tuya_list_head       encoded_frame_node_list;
+    /* The list cannot say: it is also empty when every node is out with the
+     * driver. */
+    bool                        raw_pool_inited;
+    bool                        encoded_pool_inited;
 
     TDD_CAMERA_DEV_HANDLE_T     tdd_hdl;
     TDD_CAMERA_INTFS_T          intfs;
@@ -348,16 +352,23 @@ OPERATE_RET tdl_camera_dev_open(TDL_CAMERA_HANDLE_T camera_hdl,  TDL_CAMERA_CFG_
 
     raw_buf_len = cfg->width * cfg->height * CAMERA_RAW_PER_PIXEL_MAX_BYTE;
 
+    /* The pool belongs to the registered device, not to one session. */
     if(cfg->out_fmt & TDL_IMG_FMT_RAW_MASK) {
-        TUYA_CALL_ERR_RETURN(__camera_frame_node_init(&camera_dev->raw_frame_node_list, \
-                                                      CAMERA_RAW_FRAME_BUFF_CNT, raw_buf_len));
+        if(!camera_dev->raw_pool_inited) {
+            TUYA_CALL_ERR_RETURN(__camera_frame_node_init(&camera_dev->raw_frame_node_list, \
+                                                          CAMERA_RAW_FRAME_BUFF_CNT, raw_buf_len));
+            camera_dev->raw_pool_inited = true;
+        }
         camera_dev->get_raw_frame_cb = cfg->get_frame_cb;
     }
 
     if(cfg->out_fmt & TDL_IMG_FMT_ENCODED_MASK) {
         uint32_t encoded_buf_len = (raw_buf_len * CAMERA_ENCODE_MIN_COMP_PCT + 99) / 100;
-        TUYA_CALL_ERR_RETURN(__camera_frame_node_init(&camera_dev->encoded_frame_node_list, \
-                                                      CAMERA_ENCODE_FRAME_BUFF_CNT, encoded_buf_len));
+        if(!camera_dev->encoded_pool_inited) {
+            TUYA_CALL_ERR_RETURN(__camera_frame_node_init(&camera_dev->encoded_frame_node_list, \
+                                                          CAMERA_ENCODE_FRAME_BUFF_CNT, encoded_buf_len));
+            camera_dev->encoded_pool_inited = true;
+        }
         camera_dev->get_encoded_frame_cb = cfg->get_encoded_frame_cb;
     }  
     
@@ -385,13 +396,32 @@ OPERATE_RET tdl_camera_dev_open(TDL_CAMERA_HANDLE_T camera_hdl,  TDL_CAMERA_CFG_
 }
 
 /**
- * @brief Close camera device
+ * @brief Stop the camera's output, leaving the device open
  * @param camera_hdl Camera handle
- * @return OPRT_NOT_SUPPORTED (function not implemented)
+ * @return OPRT_OK on success
+ *
+ * The frame pool is left standing: nothing records where a node is between
+ * create_tdd_frame and release_tdd_frame, so no moment here is a safe one to
+ * free them in.
  */
 OPERATE_RET tdl_camera_dev_close(TDL_CAMERA_HANDLE_T camera_hdl)
 {
-    return OPRT_NOT_SUPPORTED;
+    CAMERA_DEVICE_T *camera_dev = (CAMERA_DEVICE_T *)camera_hdl;
+
+    if (NULL == camera_dev) {
+        return OPRT_INVALID_PARM;
+    }
+    if (false == camera_dev->is_open) {
+        return OPRT_OK;
+    }
+    /* Cleared first, so queued frames drain without reaching a closed app. */
+    camera_dev->is_open = false;
+
+    if (camera_dev->intfs.close) {
+        return camera_dev->intfs.close(camera_dev->tdd_hdl);
+    }
+
+    return OPRT_OK;
 }
 
 /**


### PR DESCRIPTION
Opening a camera does two jobs at once: it brings up the board - I2C, power, the reset pulse, the DVP block, the sensor's register set - and it builds the frame pool that carries pictures to the application. Closing one does neither, because tdl_camera_dev_close and the DVP driver behind it both return NOT_SUPPORTED.

That goes unnoticed for as long as nobody reopens a camera, and today nobody quite does: ui/camera_screen.c guards its open with a camera_initialized latch that is never cleared, and ai_video_input.c guards its close with `if (NULL == sg_camera_hdl)`, so neither ever runs a second open. camera_demo does reopen, once per viewer, and works around the missing close by calling tkl_dvp_deinit() itself - the comment there records that without it the DVP's DMA channel stays claimed and the next open fails.

What that workaround cannot reach is the frame pool, and each open builds another without releasing the last. Measured on a T5AI board with a GC2145 at 480x480 H.264, that is 8 buffers of 138240 bytes: six reconnects took free PSRAM from 6.1 MB to 2188, at which point the camera could not open at all and every 1600-byte packet buffer failed with it.

Separate the two jobs. tkl_dvp_start and tkl_dvp_stop are already implemented and have no callers anywhere in the tree; they are exactly what a session is worth. open() now runs the bring-up only the first time and otherwise just starts the output, close() stops it, and the pool is built once for the device that owns it. The same six reconnects now cost about 1.3 KB apiece, and the second and later opens no longer re-run the I2C, reset and set_ppi sequence.

The pool is deliberately not freed on close. Its nodes go out to the driver through tdl_camera_create_tdd_frame and come back only through tdl_camera_release_tdd_frame, and nothing records where one is in between, so there is no moment at which freeing them is known to be safe and a node released afterwards would be linked into memory that is gone. Holding them for as long as the device is registered is what a registered device is for. A reopen asking for a larger buffer than the pool holds is refused rather than silently undersized.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
