### PR TITLE
feat(waveshare-t5ai-amoled): switch power/PTT buttons from timer-scan…

### DIFF
--- a/boards/T5AI/WAVESHARE_T5AI_TOUCH_AMOLED_1_75/board_com_api.c
+++ b/boards/T5AI/WAVESHARE_T5AI_TOUCH_AMOLED_1_75/board_com_api.c
@@ -123,8 +123,8 @@ static OPERATE_RET __board_register_button(void)
     BUTTON_GPIO_CFG_T button_2_hw_cfg = {
         .pin = BOARD_BUTTON_PWR_PIN,
         .level = BOARD_BUTTON_PWR_ACTIVE_LV,
-        .mode = BUTTON_TIMER_SCAN_MODE,
-        .pin_type.gpio_pull = TUYA_GPIO_PULLUP,
+        .mode = BUTTON_IRQ_MODE,
+        .pin_type.irq_edge = TUYA_GPIO_IRQ_FALL,
     };
 
     TUYA_CALL_ERR_RETURN(tdd_gpio_button_register(BOARD_BUTTON_PWR_NAME, &button_2_hw_cfg));
@@ -144,8 +144,8 @@ static OPERATE_RET __board_register_button(void)
     BUTTON_GPIO_CFG_T button_hw_cfg = {
         .pin = BOARD_BUTTON_PIN,
         .level = BOARD_BUTTON_ACTIVE_LV,
-        .mode = BUTTON_TIMER_SCAN_MODE,
-        .pin_type.gpio_pull = TUYA_GPIO_PULLUP,
+        .mode = BUTTON_IRQ_MODE,
+        .pin_type.irq_edge = TUYA_GPIO_IRQ_FALL,
     };
 
     TUYA_CALL_ERR_RETURN(tdd_gpio_button_register(BUTTON_NAME, &button_hw_cfg));


### PR DESCRIPTION
… to IRQ mode

Power savings, matching the pattern already used on 12 other T5AI boards (e.g. TUYA_T5AI_DESKTOP_ROBOT). Both buttons on this button manager must share the same mode, so power button and PTT button switch together. TUYA_GPIO_IRQ_RISE_FALL is not supported on this platform's tkl_gpio_irq_init(); TUYA_GPIO_IRQ_FALL matches the existing precedent.

Verified on hardware: boot log shows both tdd_gpio_button_register and tdl_button_create succeeding, the button_irq task starting and sleeping on the semaphore between presses, and a real PTT press/long-hold/release cycle correctly generating events. No faults or resets observed.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
