### PR TITLE
fix(export): quiet the first-run download log

### DIFF
--- a/export.ps1
+++ b/export.ps1
@@ -1287,11 +1287,15 @@ function Invoke-TuyaPythonInstallAttempt {
         [Parameter(Mandatory)][string]$UvExe,
         [Parameter(Mandatory)][string]$Version,
         [Parameter(Mandatory)][string]$InstallDir,
-        [Parameter(Mandatory)][string]$Source
+        [Parameter(Mandatory)][string]$Source,
+        # Route uv through the progress parser instead of letting it write to
+        # the console: used for an attempt that still has a fallback left, so a
+        # recoverable mirror failure shows a summary line, not uv's error chain.
+        [switch]$Streamed
     )
     Reset-TuyaUvDiag
     Write-TuyaOpenInfo "[TuyaOpen] Installing Python $Version from $Source..."
-    if ($script:TuyaOpenIdeHost) {
+    if ($script:TuyaOpenIdeHost -or $Streamed) {
         return (Invoke-TuyaUvPythonInstallWithIdeProgress -UvExe $UvExe -Version $Version -InstallDir $InstallDir)
     }
     Invoke-TuyaUvNative -UvExe $UvExe -WithProgress -ArgumentList @(
@@ -1322,12 +1326,15 @@ function Install-TuyaPython {
         $env:UV_PYTHON_INSTALL_MIRROR = $script:TuyaPythonInstallMirrorCn
         Write-TuyaOpenDebug "[TuyaOpen] Python mirror URL: $($script:TuyaPythonInstallMirrorCn)"
         try {
-            $exitCode = Invoke-TuyaPythonInstallAttempt -UvExe $UvExe -Version $version -InstallDir $installDir -Source 'npmmirror (CN mirror)'
+            $exitCode = Invoke-TuyaPythonInstallAttempt -UvExe $UvExe -Version $version -InstallDir $installDir -Source 'npmmirror (CN mirror)' -Streamed
         } finally {
             Remove-Item Env:UV_PYTHON_INSTALL_MIRROR -ErrorAction SilentlyContinue
         }
         if ($exitCode -ne 0) {
-            Write-TuyaOpenInfo "[TuyaOpen] CN Python mirror failed (exit $exitCode); falling back to default source (GitHub)..."
+            $cnReason = if (Test-TuyaUvDiagIsNetwork) { 'network error' } else { "exit $exitCode" }
+            Write-TuyaOpenInfo "[TuyaOpen] CN Python mirror failed ($cnReason); falling back to default source (GitHub)..."
+            # uv's full error chain is noise on a recoverable fallback; keep it for -v.
+            if ($script:TuyaOpenVerbose) { Write-TuyaUvDiag }
             $exitCode = Invoke-TuyaPythonInstallAttempt -UvExe $UvExe -Version $version -InstallDir $installDir -Source 'GitHub (default)'
         }
     } else {

--- a/export.sh
+++ b/export.sh
@@ -276,21 +276,26 @@ tuya_uv_run_stream() {
         # watchdog explains total silence after 10 seconds.
         _tuya_uv_sentinel="$fifo.out"
         rm -f "$_tuya_uv_sentinel" 2>/dev/null || true
-        (
-            sleep 10
-            [ -e "$_tuya_uv_sentinel" ] && exit 0
-            kill -0 "$uv_pid" 2>/dev/null || exit 0
-            tuya_warn_uv_lock_contention 'uv has produced no output for 10+ seconds; it may be waiting to acquire a lock held by another uv process.'
-        ) &
-        _tuya_uv_watchdog=$!
+        _tuya_uv_watchdog=0
+        if [ "${_tuya_uv_no_watchdog:-0}" -ne 1 ]; then
+            (
+                sleep 10
+                [ -e "$_tuya_uv_sentinel" ] && exit 0
+                kill -0 "$uv_pid" 2>/dev/null || exit 0
+                tuya_warn_uv_lock_contention 'uv has produced no output for 10+ seconds; it may be waiting to acquire a lock held by another uv process.'
+            ) &
+            _tuya_uv_watchdog=$!
+        fi
         while IFS= read -r line; do
             [ -e "$_tuya_uv_sentinel" ] || : > "$_tuya_uv_sentinel"
             tuya_uv_capture_diag "$line"
             [ -n "$line" ] && "$on_line" "$line"
         done <"$fifo"
         wait "$uv_pid" || rc=$?
-        kill "$_tuya_uv_watchdog" 2>/dev/null || true
-        wait "$_tuya_uv_watchdog" 2>/dev/null || true
+        if [ "$_tuya_uv_watchdog" -ne 0 ]; then
+            kill "$_tuya_uv_watchdog" 2>/dev/null || true
+            wait "$_tuya_uv_watchdog" 2>/dev/null || true
+        fi
         trap - INT TERM
         [ -n "$_tuya_saved_traps" ] && eval "$_tuya_saved_traps" 2>/dev/null
         rm -f "$_tuya_uv_sentinel" 2>/dev/null || true
@@ -475,7 +480,7 @@ tuya_cleanup() {
     unset _tuya_sync_current _tuya_sync_last_name _tuya_sync_pkg_total
     unset _tuya_py_artifact _tuya_py_total_mib _tuya_py_recv_mib
     unset _tuya_prog_last_text _tuya_prog_last_at _tuya_prog_last_pct
-    unset _tuya_uv_diag
+    unset _tuya_uv_diag _tuya_uv_no_watchdog
     unset -f tuya_debug tuya_error \
              tuya_is_sdk_root tuya_print_version tuya_has_cmd \
              tuya_ensure_dir tuya_path_add \
@@ -1012,15 +1017,16 @@ tuya_uv_source_label() {
 }
 
 tuya_download_uv() {
-    local url attempt mirror=0 total=0 rc=1 src=''
+    local url attempt mirror=0 total=0 rc=1 src='' size_human=''
+    size_human=$(tuya_human_size "${_tuya_uv_dl_size:-0}")
     total=$(tuya_get_uv_download_urls | wc -l | awk '{print $1}')
     for url in $(tuya_get_uv_download_urls); do
         mirror=$((mirror + 1))
         src=$(tuya_uv_source_label "$url")
-        if [ "$total" -gt 1 ]; then
-            tuya_info "[TuyaOpen] Downloading ${_tuya_uv_artifact} from ${src} (source ${mirror}/${total})"
+        if [ "$mirror" -eq 1 ]; then
+            tuya_info "[TuyaOpen] Downloading uv v${_tuya_uv_ver} (${size_human}) from ${src}..."
         else
-            tuya_info "[TuyaOpen] Downloading ${_tuya_uv_artifact} from ${src}"
+            tuya_info "[TuyaOpen] Downloading uv v${_tuya_uv_ver} from ${src} (source ${mirror}/${total})..."
         fi
         tuya_debug "[TuyaOpen] URL: $url"
         attempt=1
@@ -1057,10 +1063,7 @@ tuya_resolve_uv() {
     fi
 
     tuya_ensure_dir "$(dirname "$_tuya_uv_archive")" || return 1
-    local size_human
-    size_human=$(tuya_human_size "${_tuya_uv_dl_size:-0}")
     [ -n "${_tuya_region_msg:-}" ] && tuya_info "$_tuya_region_msg"
-    tuya_info "[TuyaOpen] Downloading uv v${_tuya_uv_ver} (${size_human})..."
     if ! tuya_download_uv; then
         tuya_error Uv 'uv download failed.' 'All mirrors and retries exhausted.' \
             'Check network or proxy.' 'See manual install below.'
@@ -1212,8 +1215,10 @@ tuya_install_python_ide() {
     _tuya_prog_last_text=''
     _tuya_prog_last_at=0
     _tuya_prog_last_pct=-1
+    _tuya_uv_no_watchdog=1
     tuya_uv_run_stream tuya_parse_python_install_line \
         python install "$TUYA_PYTHON_VERSION" --install-dir "$install_dir" --no-registry --no-bin || rc=$?
+    _tuya_uv_no_watchdog=0
     return "$rc"
 }
 
@@ -1238,10 +1243,13 @@ tuya_python_install_error() {
 # Run one `uv python install` attempt, announcing the source it downloads from
 # (so the origin is visible in logs for later diagnosis).
 tuya_run_python_install() {
-    local install_dir="$1" src="$2" rc=0
+    # $3=1 routes uv through the progress parser instead of letting it write to
+    # the terminal: used for an attempt that still has a fallback left, so a
+    # recoverable mirror failure shows a summary line, not uv's raw error chain.
+    local install_dir="$1" src="$2" quiet="${3:-0}" rc=0
     tuya_uv_reset_diag
     tuya_info "[TuyaOpen] Installing Python $TUYA_PYTHON_VERSION from ${src}..."
-    if tuya_is_ide_host; then
+    if tuya_is_ide_host || [ "$quiet" -eq 1 ]; then
         tuya_install_python_ide || rc=$?
     else
         tuya_uv --with-progress python install "$TUYA_PYTHON_VERSION" \
@@ -1251,7 +1259,7 @@ tuya_run_python_install() {
 }
 
 tuya_install_python() {
-    local install_dir rc=0 saved_py_mirror=""
+    local install_dir rc=0 saved_py_mirror="" reason=""
     install_dir=$(tuya_python_install_dir)
     saved_py_mirror="${UV_PYTHON_INSTALL_MIRROR:-}"
 
@@ -1269,13 +1277,20 @@ tuya_install_python() {
         UV_PYTHON_INSTALL_MIRROR="$TUYA_PYTHON_INSTALL_MIRROR_CN"
         export UV_PYTHON_INSTALL_MIRROR
         tuya_debug "[TuyaOpen] Python mirror URL: $TUYA_PYTHON_INSTALL_MIRROR_CN"
-        tuya_run_python_install "$install_dir" 'npmmirror (CN mirror)'
+        tuya_run_python_install "$install_dir" 'npmmirror (CN mirror)' 1
         rc=$?
         unset UV_PYTHON_INSTALL_MIRROR
         if [ "$rc" -eq 0 ]; then
             return 0
         fi
-        tuya_info "[TuyaOpen] CN Python mirror failed (exit ${rc}); falling back to default source (GitHub)..."
+        if tuya_uv_diag_is_network; then
+            reason='network error'
+        else
+            reason="exit ${rc}"
+        fi
+        tuya_info "[TuyaOpen] CN Python mirror failed (${reason}); falling back to default source (GitHub)..."
+        # uv's full error chain is noise on a recoverable fallback; keep it for -v.
+        [ -n "${TUYAOPEN_EXPORT_VERBOSE:-}" ] && tuya_uv_print_diag
     fi
 
     # Default source (GitHub) — first choice overseas, fallback in CN.


### PR DESCRIPTION
The first `. ./export.sh` in mainland China printed two "Downloading" lines for the same uv archive, and, when the CN Python mirror was unreachable, dumped uv's whole seven-line `error:/Caused by:` chain before announcing the GitHub fallback -- noise for a failure the script recovers from on its own.

- Announce the uv archive once per source, with version and size: `Downloading uv v0.11.18 (23 MB) from tuyacn...`; later sources keep the `(source N/M)` suffix.
- Run the Python install attempt that still has a fallback through the progress parser, so the mirror failure collapses to one line naming the real cause (`network error` vs `exit N`). The full uv output stays in the diagnostics buffer: printed under TUYAOPEN_EXPORT_VERBOSE, and still printed in full when the last attempt fails.
- Skip the "waiting to acquire a lock" watchdog for `uv python install`. It is about `uv sync` waiting on the venv lock; an install downloading from a slow or dead mirror is silent for 10+ seconds too, and the hint is wrong there.

Verified with a bogus mirror: no raw error chain leaks, the cause is classified as a network error, and -v still shows uv's output.

### PR 描述/PR description
[在此详细描述 PR 的内容]/[Describe the PR content in detail here]


### 代码质量/Code Quality:
在本次拉取请求中，我已考虑以下事项 As part of this pull request, I've considered the following:
- [ ] 确保代码注释和文档清晰，并使用英文注释以保证代码可读性。Ensure that the code comments and documentation are clear, and use English for comments to ensure code readability.
- [ ] 确保文件头遵循[文件头格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E5%A4%B4%E6%96%87%E4%BB%B6)。Ensure that the file header follows the [File Header Format](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#file-header-format).
- [ ] 确保函数头遵循 [Doxygen 格式](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%B3%A8%E9%87%8A)。Ensure that function headers follow the Doxygen format as specified in [Comments](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#comments).
- [ ] 已查阅 [编码风格指南](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide)，并核查代码风格合规性，包括缩进、空格、命名规范及其他风格要求。 Reviewed the [Coding Style Guide](https://www.tuyaopen.ai/docs/contribute/coding-style-guide) and verified code style compliance, including indentation, spacing, naming conventions, and other style guidelines.
- [ ] 已使用[代码格式化工具](https://www.tuyaopen.ai/zh/docs/contribute/coding-style-guide#%E6%A0%BC%E5%BC%8F%E5%8C%96%E4%BB%A3%E7%A0%81)确保符合 TuyaOpen 编码规范。Have used the [code-formatting](https://www.tuyaopen.ai/docs/contribute/coding-style-guide#code-formatting) source code formatting tool to ensure compliance with TuyaOpen coding standards.
