### PR TITLE
fix(ble): resolve vulnerabilities TO-01 through TO-16 in BLE stack and schema

### DIFF
--- a/src/tuya_cloud_service/ble/ble_channel.c
+++ b/src/tuya_cloud_service/ble/ble_channel.c
@@ -95,9 +95,9 @@ int ble_channel_del(ble_channel_type_t type)
     return OPRT_INVALID_PARM;
 }
 
-static void ble_channel_process(void *data)
+static void ble_channel_process(void *data, uint32_t len)
 {
-    if (NULL == data) {
+    if (NULL == data || len < 2) {
         return;
     }
     uint8_t *user_data = (uint8_t *)data;
@@ -297,7 +297,7 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
                 }
                 uint32_t extracted_len =
                     __extract_packet_len(pRawData + offset, pRawLen - offset, &s_channel_total_len);
-                if (extracted_len == 0 || s_channel_total_len == 0 || s_channel_total_len > TUYA_BLE_AIR_FRAME_MAX) {
+                if (extracted_len == 0 || s_channel_total_len < 2 || s_channel_total_len > TUYA_BLE_AIR_FRAME_MAX) {
                     PR_ERR("invalid channel totalLen: %u", s_channel_total_len);
                     ble_channel_reset();
                     return;
@@ -390,13 +390,13 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
 
                 s_channel_buffer[s_channel_total_len] = 0;
                 tuya_ble_raw_print("recv_donwlink_cmd", 16, s_channel_buffer, s_channel_total_len);
-                ble_channel_process(s_channel_buffer);
+                ble_channel_process(s_channel_buffer, s_channel_total_len);
                 ble_channel_reset();
             }
         } else { // not subpacket process
-            if (pRawLen >= 2) {
+            if (pRawLen >= 4) {
                 tuya_ble_raw_print("recv_downlink_cmd", 16, pRawData, pRawLen);
-                ble_channel_process(pRawData + 2);
+                ble_channel_process(pRawData + 2, pRawLen - 2);
             }
         }
     } else if (FRM_UPLINK_TRANSPARENT_REQ == req->type || FRM_UPLINK_TRANSPARENT_SPEC_REQ == req->type) {

--- a/src/tuya_cloud_service/ble/ble_channel.c
+++ b/src/tuya_cloud_service/ble/ble_channel.c
@@ -119,8 +119,9 @@ static void ble_channel_process(void *data, uint32_t len)
 static uint32_t s_channel_total_len = 0;
 static uint8_t *s_channel_buffer = NULL;
 static uint32_t s_channel_received_len = 0;
+static uint32_t s_channel_expected_no = 0;
 
-void ble_channel_reset(void)
+void ble_channel_rx_reset(void)
 {
     if (s_channel_buffer) {
         tal_free(s_channel_buffer);
@@ -128,11 +129,22 @@ void ble_channel_reset(void)
     }
     s_channel_total_len = 0;
     s_channel_received_len = 0;
+    s_channel_expected_no = 0;
+}
+
+void ble_channel_tx_reset(void)
+{
     if (s_ble_channel_mgr.rsp_data) {
         tal_free(s_ble_channel_mgr.rsp_data);
         s_ble_channel_mgr.rsp_data = NULL;
     }
     memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
+}
+
+void ble_channel_reset(void)
+{
+    ble_channel_rx_reset();
+    ble_channel_tx_reset();
 }
 
 uint32_t __extract_packet_len(uint8_t *raw_data, uint32_t max_len, uint32_t *pNum)
@@ -234,8 +246,13 @@ static void __response_to_app_by_subpack(uint16_t type)
  * @param data The data of the response.
  * @param len The length of the response.
  */
-void ble_channle_ack(uint16_t type, uint8_t *data, uint32_t len)
+int ble_channle_ack(uint16_t type, uint8_t *data, uint32_t len)
 {
+    if (NULL == data || len < 4) {
+        PR_ERR("invalid ack params: data=%p, len=%u", data, len);
+        return OPRT_INVALID_PARM;
+    }
+
     if (s_ble_channel_mgr.rsp_data) {
         PR_ERR("pre subpack data overwrite!");
         tal_free(s_ble_channel_mgr.rsp_data);
@@ -248,6 +265,7 @@ void ble_channle_ack(uint16_t type, uint8_t *data, uint32_t len)
 
     PR_DEBUG("start to send subpack cmd:%x, subcmd:%x", type, data[3]);
     __response_to_app_by_subpack(type);
+    return OPRT_OK;
 }
 
 /**
@@ -289,17 +307,18 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
 
             if (pRawData[2] == 0) { // first subpacket
                 offset = 3;         // skip flag and first subpacket no, total 3B
-                ble_channel_reset();
+                ble_channel_rx_reset();
 
                 if (offset >= pRawLen) {
                     PR_ERR("pRawLen %u <= offset %u", pRawLen, offset);
+                    ble_channel_rx_reset();
                     return;
                 }
                 uint32_t extracted_len =
                     __extract_packet_len(pRawData + offset, pRawLen - offset, &s_channel_total_len);
                 if (extracted_len == 0 || s_channel_total_len < 2 || s_channel_total_len > TUYA_BLE_AIR_FRAME_MAX) {
                     PR_ERR("invalid channel totalLen: %u", s_channel_total_len);
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 offset += extracted_len;
@@ -308,7 +327,7 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
                 s_channel_buffer = tal_malloc(s_channel_total_len + 1);
                 if (NULL == s_channel_buffer) {
                     PR_ERR("malloc error for s_channel_buffer");
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 memset(s_channel_buffer, 0, s_channel_total_len + 1);
@@ -316,49 +335,76 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
                 offset += 1; // skip version and reserve, total 1B
                 if (offset > pRawLen) {
                     PR_ERR("offset %u > pRawLen %u", offset, pRawLen);
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 curSubpacketLen = pRawLen - offset;
                 if (curSubpacketLen > s_channel_total_len) {
                     PR_ERR("curSubpacketLen %u > totalLen %u", curSubpacketLen, s_channel_total_len);
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 memcpy(s_channel_buffer + s_channel_received_len, pRawData + offset, curSubpacketLen);
                 s_channel_received_len += curSubpacketLen;
                 curSubpacketNo = 0;
+                s_channel_expected_no = 1;
             } else { // subsequent subpackets
                 if (NULL == s_channel_buffer || s_channel_total_len == 0) {
                     PR_ERR("s_channel_buffer is NULL in subsequent subpacket");
+                    ble_channel_rx_reset();
                     return;
                 }
 
                 offset = 2; // skip flag, total 2B
                 if (offset >= pRawLen) {
                     PR_ERR("pRawLen %u <= offset %u", pRawLen, offset);
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 uint32_t extracted_len = __extract_packet_len(pRawData + offset, pRawLen - offset, &curSubpacketNo);
                 if (extracted_len == 0) {
                     PR_ERR("extract curSubpacketNo failed");
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 offset += extracted_len;
                 if (offset > pRawLen) {
                     PR_ERR("offset %u > pRawLen %u", offset, pRawLen);
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
                 curSubpacketLen = pRawLen - offset;
                 if (curSubpacketLen > s_channel_total_len - s_channel_received_len) {
                     PR_ERR("curSubpacketLen %u > remaining space %u", curSubpacketLen,
                            s_channel_total_len - s_channel_received_len);
-                    ble_channel_reset();
+                    ble_channel_rx_reset();
                     return;
                 }
+
+                // Verify subpacket sequence
+                if (curSubpacketNo == s_channel_expected_no - 1) {
+                    // Duplicate packet received; re-ack without re-appending
+                    PR_DEBUG("duplicate subpacket %u received, re-sending ack", curSubpacketNo);
+                    ble_channel_ack_t *pAck = tal_malloc(sizeof(ble_channel_ack_t));
+                    if (pAck) {
+                        pAck->flag = (pRawData[1] << 8) | pRawData[0];
+                        pAck->curSubpacketNo = curSubpacketNo;
+                        pAck->cursubpacketLen = curSubpacketLen;
+                        pAck->receivedLen = s_channel_received_len;
+                        pAck->totalLen = s_channel_total_len;
+                        pAck->status = (s_channel_received_len < s_channel_total_len) ? SUBPACKET_RECV_ONE_AND_NEXT : SUBPACKET_RECV_ALL_DONE;
+                        tuya_ble_send(req->type, req->sn, (uint8_t *)pAck, sizeof(ble_channel_ack_t));
+                        tal_free(pAck);
+                    }
+                    return;
+                }
+                if (curSubpacketNo != s_channel_expected_no) {
+                    PR_ERR("subpacket order error: got %u, expected %u", curSubpacketNo, s_channel_expected_no);
+                    ble_channel_rx_reset();
+                    return;
+                }
+
+                s_channel_expected_no++;
                 memcpy(s_channel_buffer + s_channel_received_len, pRawData + offset, curSubpacketLen);
                 s_channel_received_len += curSubpacketLen;
             }
@@ -370,7 +416,7 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
             ble_channel_ack_t *pAck = tal_malloc(sizeof(ble_channel_ack_t));
             if (pAck == NULL) {
                 PR_ERR("malloc error for pAck");
-                ble_channel_reset();
+                ble_channel_rx_reset();
                 return;
             }
             pAck->flag = (pRawData[1] << 8) | pRawData[0];
@@ -391,7 +437,7 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
                 s_channel_buffer[s_channel_total_len] = 0;
                 tuya_ble_raw_print("recv_donwlink_cmd", 16, s_channel_buffer, s_channel_total_len);
                 ble_channel_process(s_channel_buffer, s_channel_total_len);
-                ble_channel_reset();
+                ble_channel_rx_reset();
             }
         } else { // not subpacket process
             if (pRawLen >= 4) {
@@ -404,10 +450,7 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
             tuya_ble_raw_print("recv_uplink_frame", 16, pRawData, pRawLen);
             uint8_t status = pRawData[2];
             if (status == 0) { // complete subpack send
-                if (s_ble_channel_mgr.rsp_data) {
-                    tal_free(s_ble_channel_mgr.rsp_data);
-                }
-                memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
+                ble_channel_tx_reset();
             } else if (status == 1) { // continue subpack send
                 __response_to_app_by_subpack(req->type);
             } else if (status == 2) { // restart subpack send

--- a/src/tuya_cloud_service/ble/ble_channel.c
+++ b/src/tuya_cloud_service/ble/ble_channel.c
@@ -97,6 +97,9 @@ int ble_channel_del(ble_channel_type_t type)
 
 static void ble_channel_process(void *data)
 {
+    if (NULL == data) {
+        return;
+    }
     uint8_t *user_data = (uint8_t *)data;
     uint16_t type = (user_data[0] << 8) | (user_data[1]);
 
@@ -113,7 +116,26 @@ static void ble_channel_process(void *data)
     }
 }
 
-uint32_t __extract_packet_len(uint8_t *raw_data, uint32_t *pNum)
+static uint32_t s_channel_total_len = 0;
+static uint8_t *s_channel_buffer = NULL;
+static uint32_t s_channel_received_len = 0;
+
+void ble_channel_reset(void)
+{
+    if (s_channel_buffer) {
+        tal_free(s_channel_buffer);
+        s_channel_buffer = NULL;
+    }
+    s_channel_total_len = 0;
+    s_channel_received_len = 0;
+    if (s_ble_channel_mgr.rsp_data) {
+        tal_free(s_ble_channel_mgr.rsp_data);
+        s_ble_channel_mgr.rsp_data = NULL;
+    }
+    memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
+}
+
+uint32_t __extract_packet_len(uint8_t *raw_data, uint32_t max_len, uint32_t *pNum)
 {
     uint8_t i = 0;
     uint32_t multiplier = 1;
@@ -121,18 +143,25 @@ uint32_t __extract_packet_len(uint8_t *raw_data, uint32_t *pNum)
     uint8_t offset = 0;
     uint32_t num = 0;
 
-    for (i = 0; i < 4; i++) {
+    if (NULL == raw_data || NULL == pNum || max_len == 0) {
+        if (pNum) {
+            *pNum = 0;
+        }
+        return 0;
+    }
+
+    for (i = 0; i < 4 && offset < max_len; i++) {
         digit = raw_data[offset++];
         num += (digit & 0x7f) * multiplier;
         multiplier *= 0x80;
 
         if (0 == (digit & 0x80)) {
-            break;
+            *pNum = num;
+            return offset;
         }
     }
-    *pNum = num;
-
-    return offset;
+    *pNum = 0;
+    return 0;
 }
 
 static void __response_to_app_by_subpack(uint16_t type)
@@ -235,6 +264,10 @@ void ble_channle_ack(uint16_t type, uint8_t *data, uint32_t len)
  */
 void ble_session_channel_process(ble_packet_t *req, void *user_data)
 {
+    if (NULL == req || NULL == req->data || req->len < 3) {
+        return;
+    }
+
     if (!(req->type == FRM_DOWNLINK_TRANSPARENT_REQ || req->type == FRM_DOWNLINK_TRANSPARENT_SPEC_REQ ||
           req->type == FRM_UPLINK_TRANSPARENT_REQ || req->type == FRM_UPLINK_TRANSPARENT_SPEC_REQ)) {
         return;
@@ -253,65 +286,100 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
             uint32_t offset = 0;
             uint32_t curSubpacketNo = 0;
             uint32_t curSubpacketLen = 0;
-            static uint32_t totalLen = 0; // all subpackets data length
-            static uint8_t *pBuffer = NULL;
-            static uint32_t receivedLen = 0; // already received subpackets data length
 
             if (pRawData[2] == 0) { // first subpacket
                 offset = 3;         // skip flag and first subpacket no, total 3B
-                totalLen = 0;
-                receivedLen = 0;
-                offset += __extract_packet_len(pRawData + offset,
-                                               &totalLen); // parse all subpackets data length
-                PR_DEBUG("first downlink subpacket, totalLen:%u", totalLen);
+                ble_channel_reset();
 
-                if (pBuffer) {
-                    tal_free(pBuffer);
-                    pBuffer = NULL;
-                }
-                pBuffer = tal_malloc(totalLen);
-                if (NULL == pBuffer) {
-                    PR_ERR("malloc error for pBuffer in __handle_bt_timer_task");
+                if (offset >= pRawLen) {
+                    PR_ERR("pRawLen %u <= offset %u", pRawLen, offset);
                     return;
                 }
+                uint32_t extracted_len =
+                    __extract_packet_len(pRawData + offset, pRawLen - offset, &s_channel_total_len);
+                if (extracted_len == 0 || s_channel_total_len == 0 || s_channel_total_len > TUYA_BLE_AIR_FRAME_MAX) {
+                    PR_ERR("invalid channel totalLen: %u", s_channel_total_len);
+                    ble_channel_reset();
+                    return;
+                }
+                offset += extracted_len;
+                PR_DEBUG("first downlink subpacket, totalLen:%u", s_channel_total_len);
+
+                s_channel_buffer = tal_malloc(s_channel_total_len + 1);
+                if (NULL == s_channel_buffer) {
+                    PR_ERR("malloc error for s_channel_buffer");
+                    ble_channel_reset();
+                    return;
+                }
+                memset(s_channel_buffer, 0, s_channel_total_len + 1);
 
                 offset += 1; // skip version and reserve, total 1B
+                if (offset > pRawLen) {
+                    PR_ERR("offset %u > pRawLen %u", offset, pRawLen);
+                    ble_channel_reset();
+                    return;
+                }
                 curSubpacketLen = pRawLen - offset;
-                memcpy(pBuffer + receivedLen, pRawData + offset, curSubpacketLen);
-                receivedLen += curSubpacketLen;
+                if (curSubpacketLen > s_channel_total_len) {
+                    PR_ERR("curSubpacketLen %u > totalLen %u", curSubpacketLen, s_channel_total_len);
+                    ble_channel_reset();
+                    return;
+                }
+                memcpy(s_channel_buffer + s_channel_received_len, pRawData + offset, curSubpacketLen);
+                s_channel_received_len += curSubpacketLen;
                 curSubpacketNo = 0;
             } else { // subsequent subpackets
-                if (NULL == pBuffer) {
-                    PR_ERR("malloc error for pBuffer in __handle_bt_timer_task");
+                if (NULL == s_channel_buffer || s_channel_total_len == 0) {
+                    PR_ERR("s_channel_buffer is NULL in subsequent subpacket");
                     return;
                 }
 
                 offset = 2; // skip flag, total 2B
-                offset += __extract_packet_len(pRawData + offset,
-                                               &curSubpacketNo); // parse current subpacket no
+                if (offset >= pRawLen) {
+                    PR_ERR("pRawLen %u <= offset %u", pRawLen, offset);
+                    ble_channel_reset();
+                    return;
+                }
+                uint32_t extracted_len = __extract_packet_len(pRawData + offset, pRawLen - offset, &curSubpacketNo);
+                if (extracted_len == 0) {
+                    PR_ERR("extract curSubpacketNo failed");
+                    ble_channel_reset();
+                    return;
+                }
+                offset += extracted_len;
+                if (offset > pRawLen) {
+                    PR_ERR("offset %u > pRawLen %u", offset, pRawLen);
+                    ble_channel_reset();
+                    return;
+                }
                 curSubpacketLen = pRawLen - offset;
-                memcpy(pBuffer + receivedLen, pRawData + offset, curSubpacketLen);
-                receivedLen += curSubpacketLen;
+                if (curSubpacketLen > s_channel_total_len - s_channel_received_len) {
+                    PR_ERR("curSubpacketLen %u > remaining space %u", curSubpacketLen,
+                           s_channel_total_len - s_channel_received_len);
+                    ble_channel_reset();
+                    return;
+                }
+                memcpy(s_channel_buffer + s_channel_received_len, pRawData + offset, curSubpacketLen);
+                s_channel_received_len += curSubpacketLen;
             }
 
             PR_DEBUG("rece downlink subpacket, curSubpacketNo:%u, "
                      "curSubpacketLen:%u, receivedLen:%u, totalLen:%u",
-                     curSubpacketNo, curSubpacketLen, receivedLen, totalLen);
+                     curSubpacketNo, curSubpacketLen, s_channel_received_len, s_channel_total_len);
 
             ble_channel_ack_t *pAck = tal_malloc(sizeof(ble_channel_ack_t));
             if (pAck == NULL) {
-                PR_ERR("malloc error for pAck in __handle_bt_timer_task");
-                tal_free(pBuffer);
-                pBuffer = NULL;
+                PR_ERR("malloc error for pAck");
+                ble_channel_reset();
                 return;
             }
             pAck->flag = (pRawData[1] << 8) | pRawData[0];
             pAck->curSubpacketNo = curSubpacketNo;
             pAck->cursubpacketLen = curSubpacketLen;
-            pAck->receivedLen = receivedLen;
-            pAck->totalLen = totalLen;
+            pAck->receivedLen = s_channel_received_len;
+            pAck->totalLen = s_channel_total_len;
 
-            if (receivedLen < totalLen) {
+            if (s_channel_received_len < s_channel_total_len) {
                 pAck->status = SUBPACKET_RECV_ONE_AND_NEXT;
                 tuya_ble_send(req->type, req->sn, (uint8_t *)pAck, sizeof(ble_channel_ack_t));
                 tal_free(pAck);
@@ -320,28 +388,34 @@ void ble_session_channel_process(ble_packet_t *req, void *user_data)
                 tuya_ble_send(req->type, req->sn, (uint8_t *)pAck, sizeof(ble_channel_ack_t));
                 tal_free(pAck);
 
-                tuya_ble_raw_print("recv_donwlink_cmd", 16, pBuffer, totalLen);
-                ble_channel_process(pBuffer);
+                s_channel_buffer[s_channel_total_len] = 0;
+                tuya_ble_raw_print("recv_donwlink_cmd", 16, s_channel_buffer, s_channel_total_len);
+                ble_channel_process(s_channel_buffer);
+                ble_channel_reset();
             }
         } else { // not subpacket process
-            tuya_ble_raw_print("recv_downlink_cmd", 16, pRawData, pRawLen);
-            ble_channel_process(pRawData + 2);
+            if (pRawLen >= 2) {
+                tuya_ble_raw_print("recv_downlink_cmd", 16, pRawData, pRawLen);
+                ble_channel_process(pRawData + 2);
+            }
         }
     } else if (FRM_UPLINK_TRANSPARENT_REQ == req->type || FRM_UPLINK_TRANSPARENT_SPEC_REQ == req->type) {
-        tuya_ble_raw_print("recv_uplink_frame", 16, pRawData, pRawLen);
-        uint8_t status = pRawData[2];
-        if (status == 0) { // complete subpack send
-            if (s_ble_channel_mgr.rsp_data) {
-                tal_free(s_ble_channel_mgr.rsp_data);
+        if (pRawLen >= 3) {
+            tuya_ble_raw_print("recv_uplink_frame", 16, pRawData, pRawLen);
+            uint8_t status = pRawData[2];
+            if (status == 0) { // complete subpack send
+                if (s_ble_channel_mgr.rsp_data) {
+                    tal_free(s_ble_channel_mgr.rsp_data);
+                }
+                memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
+            } else if (status == 1) { // continue subpack send
+                __response_to_app_by_subpack(req->type);
+            } else if (status == 2) { // restart subpack send
+                s_ble_channel_mgr.subpack_no = 0;
+                s_ble_channel_mgr.subpack_sent = 0;
+                __response_to_app_by_subpack(req->type);
+            } else {
             }
-            memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
-        } else if (status == 1) { // continue subpack send
-            __response_to_app_by_subpack(req->type);
-        } else if (status == 2) { // restart subpack send
-            s_ble_channel_mgr.subpack_no = 0;
-            s_ble_channel_mgr.subpack_sent = 0;
-            __response_to_app_by_subpack(req->type);
-        } else {
         }
     }
 }

--- a/src/tuya_cloud_service/ble/ble_channel.h
+++ b/src/tuya_cloud_service/ble/ble_channel.h
@@ -60,7 +60,10 @@ int ble_channel_del(ble_channel_type_t type);
  * channel.
  */
 void ble_session_channel_process(ble_packet_t *req, void *priv_data);
+void ble_channel_rx_reset(void);
+void ble_channel_tx_reset(void);
 void ble_channel_reset(void);
+int ble_channle_ack(uint16_t type, uint8_t *data, uint32_t len);
 
 #ifdef __cplusplus
 }

--- a/src/tuya_cloud_service/ble/ble_channel.h
+++ b/src/tuya_cloud_service/ble/ble_channel.h
@@ -60,6 +60,7 @@ int ble_channel_del(ble_channel_type_t type);
  * channel.
  */
 void ble_session_channel_process(ble_packet_t *req, void *priv_data);
+void ble_channel_reset(void);
 
 #ifdef __cplusplus
 }

--- a/src/tuya_cloud_service/ble/ble_dp.c
+++ b/src/tuya_cloud_service/ble/ble_dp.c
@@ -330,10 +330,13 @@ static OPERATE_RET __result_code_resp(uint16_t type, uint32_t ack_sn, uint8_t re
     return tuya_ble_send(type, ack_sn, &result_code, 1);
 }
 
-static OPERATE_RET __result_code_resp_v4(uint16_t type, uint32_t ack_sn, uint8_t *data, uint8_t result_code)
+static OPERATE_RET __result_code_resp_v4(uint16_t type, uint32_t ack_sn, uint8_t *data, uint16_t data_len,
+                                         uint8_t result_code)
 {
     uint8_t data_code[6] = {0}; // version(1byte)+R_SN(4byte)+STATE(1byte)
-    memcpy(data_code, data, 5);
+    if (data != NULL && data_len >= 5) {
+        memcpy(data_code, data, 5);
+    }
     data_code[5] = result_code;
 
     return tuya_ble_send(type, ack_sn, data_code, 6);
@@ -531,10 +534,15 @@ static int ble_dp_req(ble_packet_t *req, void *priv_data)
     uint8_t *data = NULL;
     uint16_t len = 0;
 
+    if (NULL == req || NULL == req->data || req->len < 5) {
+        PR_ERR("ble dp req invalid len");
+        return OPRT_INVALID_PARM;
+    }
+
     tuya_ble_raw_print("ble dp", 32, req->data, req->len);
 
     if (req->type == FRM_DP_CMD_SEND_V4) {
-        __result_code_resp_v4(FRM_DP_CMD_SEND_V4, req->sn, req->data, 0);
+        __result_code_resp_v4(FRM_DP_CMD_SEND_V4, req->sn, req->data, req->len, 0);
         data = req->data + 5;
         len = req->len - 5;
     } else {
@@ -568,6 +576,9 @@ static int ble_dp_req(ble_packet_t *req, void *priv_data)
         snprintf(dp_id_str, 5, "%d", p_tmp->id);
         switch (p_tmp->type) {
         case DT_RAW: {
+            if (NULL == p_tmp->data || 0 == p_tmp->len) {
+                break;
+            }
             char *p_base64 = tal_malloc(p_tmp->len / 3 * 4 + 5);
             if (NULL == p_base64) {
                 PR_ERR("malloc base64 failed, len:%d", p_tmp->len);
@@ -580,20 +591,33 @@ static int ble_dp_req(ble_packet_t *req, void *priv_data)
             break;
         }
         case DT_BOOL: {
+            if (NULL == p_tmp->data || p_tmp->len < 1) {
+                break;
+            }
             cJSON_AddBoolToObject(p_dps, dp_id_str, *(p_tmp->data));
             break;
         }
         case DT_BITMAP:
         case DT_VALUE: {
+            if (NULL == p_tmp->data || p_tmp->len < 4) {
+                break;
+            }
             int val = (p_tmp->data[0] << 24) + (p_tmp->data[1] << 16) + (p_tmp->data[2] << 8) + (p_tmp->data[3] << 0);
             cJSON_AddNumberToObject(p_dps, dp_id_str, val);
             break;
         }
         case DT_ENUM: {
+            if (NULL == p_tmp->data || p_tmp->len < 1) {
+                break;
+            }
             int val = p_tmp->data[0];
             dp_node_t *dpnode = dp_node_find(tuya_iot_client_get()->schema, p_tmp->id);
             if (NULL == dpnode) {
                 PR_ERR("invalid dp id[%d]", p_tmp->id);
+                break;
+            }
+            if (val >= dpnode->prop.prop_enum.cnt || NULL == dpnode->prop.prop_enum.pp_enum) {
+                PR_ERR("invalid enum val[%d], max cnt[%d]", val, dpnode->prop.prop_enum.cnt);
                 break;
             }
             cJSON_AddStringToObject(p_dps, dp_id_str, dpnode->prop.prop_enum.pp_enum[val]);
@@ -738,6 +762,10 @@ int tuya_ble_dp_report(dp_rept_in_t *dpin)
 void ble_session_dp_process(ble_packet_t *packet, void *priv_data)
 {
     int rt;
+
+    if (NULL == packet || NULL == packet->data || 0 == packet->len) {
+        return;
+    }
 
     switch (packet->type) {
 

--- a/src/tuya_cloud_service/ble/ble_mgr.c
+++ b/src/tuya_cloud_service/ble/ble_mgr.c
@@ -50,6 +50,9 @@
 #define BLE_CONN_MONITOR_TIME 30000
 /* ID  (id == uuid)*/
 #define BLE_ID_LEN 16
+#define BLE_DEV_INFO_MAX_LEN 121
+#define BLE_FRAME_PKG_LEN_MIN 20
+#define BLE_FRAME_PKG_LEN_MAX TUYA_BLE_AIR_FRAME_MAX
 typedef struct {
     ble_session_fn_t function;
     void *priv_data;
@@ -295,6 +298,10 @@ static int ble_packet_recv(tuya_ble_mgr_t *ble, uint8_t *buf, uint16_t len, ble_
         PR_ERR("ble trsmitr version not compatibility! %d", packet_recv->trsmitr->version);
         return OPRT_INVALID_PARM;
     }
+    if (*ble->is_bound && packet_recv->raw_buf[0] == ENCRYPTION_MODE_NONE) {
+        PR_ERR("ble packet rejected: plaintext mode not allowed on bound device");
+        return OPRT_SVC_BT_API_TRSMITR_ERROR;
+    }
     tuya_ble_raw_print("ble raw packet", 8, packet_recv->raw_buf, packet_recv->raw_len);
     memset(packet_recv->dec_buf, 0, TUYA_BLE_AIR_FRAME_MAX);
     rt = tuya_ble_decryption(&ble->crypto_param, packet_recv->raw_buf, packet_recv->raw_len, &packet_recv->dec_len,
@@ -341,12 +348,13 @@ static int ble_packet_recv(tuya_ble_mgr_t *ble, uint8_t *buf, uint16_t len, ble_
     packet->data = NULL;
     packet->encrypt_mode = packet_recv->raw_buf[0];
     if (0 != packet->len) {
-        packet->data = (uint8_t *)tal_malloc(packet->len);
+        packet->data = (uint8_t *)tal_malloc(packet->len + 1);
         if (packet->data == NULL) {
             PR_DEBUG("ble packet malloc err");
             return OPRT_MALLOC_FAILED;
         }
         memcpy(packet->data, &packet_recv->dec_buf[BLE_PACKET_DATA_IND], packet->len);
+        packet->data[packet->len] = 0;
     }
 
     return OPRT_OK;
@@ -599,6 +607,10 @@ static int ble_packet_resp(tuya_ble_mgr_t *ble, ble_packet_t *resp)
             goto __exit;
         }
         uint32_t send_len = ble_frame_subpacket_len_get(trsmitr);
+        if (send_len > buf_len) {
+            PR_ERR("send_len %u > buf_len %u", send_len, buf_len);
+            send_len = buf_len;
+        }
         memcpy(pbuf, ble_frame_subpacket_get(trsmitr), send_len);
         // tuya_ble_raw_print("ble trsmitr pbuf", 8, pbuf, send_len);
         TAL_BLE_DATA_T ble_data;
@@ -694,6 +706,21 @@ static int ble_unbind_req(ble_packet_t *req, void *priv_data)
     tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)priv_data;
     ble_packet_t resp;
 
+    if (!ble->is_paired) {
+        PR_ERR("ble unbind req rejected: not paired");
+        return OPRT_NOT_SUPPORTED;
+    }
+
+    if (!(*ble->is_bound)) {
+        PR_ERR("ble unbind req rejected: device not bound");
+        return OPRT_NOT_SUPPORTED;
+    }
+
+    if (req->encrypt_mode == ENCRYPTION_MODE_NONE) {
+        PR_ERR("ble unbind req rejected: plaintext not allowed");
+        return OPRT_NOT_SUPPORTED;
+    }
+
     resp.sn = req->sn;
     resp.type = req->type;
     resp.len = 1;
@@ -701,8 +728,11 @@ static int ble_unbind_req(ble_packet_t *req, void *priv_data)
     resp.encrypt_mode = req->encrypt_mode;
 
     ble_packet_resp(ble, &resp);
-    tuya_iot_reset(tuya_iot_client_get());
-    tuya_iot_client_get()->is_activated = false;
+    tuya_iot_client_t *client = tuya_iot_client_get();
+    if (client) {
+        tuya_iot_reset(client);
+        client->is_activated = false;
+    }
     tal_ble_disconnect(ble->peer_info);
 
     return OPRT_OK;
@@ -710,9 +740,14 @@ static int ble_unbind_req(ble_packet_t *req, void *priv_data)
 
 static int ble_pair_req(ble_packet_t *req, void *priv_data)
 {
-    int rt;
+    int rt = OPRT_OK;
     uint8_t result;
     tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)priv_data;
+
+    if (req == NULL || req->data == NULL || req->len < BLE_ID_LEN) {
+        PR_ERR("ble pair req invalid param");
+        return OPRT_INVALID_PARM;
+    }
 
     if (0 == memcmp(req->data, ble->crypto_param.uuid, BLE_ID_LEN)) {
         tal_sw_timer_stop(ble->pair_timer);
@@ -754,6 +789,9 @@ __exit:
 
 static uint8_t ble_dev_info_make(tuya_ble_mgr_t *ble, uint8_t *pbuf, uint8_t buflen)
 {
+    if (NULL == pbuf || buflen < BLE_DEV_INFO_MAX_LEN) {
+        return 0;
+    }
     uint8_t payload_len = 0;
 
     //! protocol version
@@ -814,25 +852,34 @@ static uint8_t ble_dev_info_make(tuya_ble_mgr_t *ble, uint8_t *pbuf, uint8_t buf
 
 static int ble_dev_info_req(ble_packet_t *req, void *priv_data)
 {
-    int rt;
+    int rt = OPRT_OK;
     uint8_t *pbuf = NULL;
     uint8_t buf_len = 128;
     tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)priv_data;
 
+    if (req == NULL || req->len < 2 || req->data == NULL) {
+        PR_ERR("ble dev info req invalid param");
+        return OPRT_INVALID_PARM;
+    }
+
     // Gets the Bluetooth subcontract length from the protocol
     uint16_t pkg_len = (req->data[0] << 8 & 0xff00) + (req->data[1] & 0xff);
-    ble_frame_packet_len_set(pkg_len);
-    ble_frame_trsmitr_t *trsmitr = ble->packet_recv->trsmitr;
-    if (trsmitr->subpkg) {
-        tal_free(trsmitr->subpkg);
-        trsmitr->subpkg = NULL;
+    if (pkg_len < BLE_FRAME_PKG_LEN_MIN || pkg_len > BLE_FRAME_PKG_LEN_MAX) {
+        PR_WARN("invalid pkg_len %u, using default %d", pkg_len, TUYA_BLE_AIR_FRAME_MAX);
+        pkg_len = TUYA_BLE_AIR_FRAME_MAX;
     }
-    trsmitr->subpkg = (uint8_t *)tal_malloc(pkg_len);
-    if (trsmitr->subpkg == NULL) {
+    ble_frame_trsmitr_t *trsmitr = ble->packet_recv->trsmitr;
+    uint8_t *new_subpkg = (uint8_t *)tal_malloc(pkg_len);
+    if (new_subpkg == NULL) {
         PR_ERR("malloc err:%d", pkg_len);
         return OPRT_MALLOC_FAILED;
     }
-    memset(trsmitr->subpkg, 0, pkg_len);
+    memset(new_subpkg, 0, pkg_len);
+    if (trsmitr->subpkg) {
+        tal_free(trsmitr->subpkg);
+    }
+    trsmitr->subpkg = new_subpkg;
+    ble_frame_packet_len_set(pkg_len);
     PR_NOTICE("ble dev info: state:%d, pkg_len:%d", *ble->is_bound, ble_frame_packet_len_get());
 
     pbuf = (uint8_t *)tal_malloc(buf_len);
@@ -842,6 +889,11 @@ static int ble_dev_info_req(ble_packet_t *req, void *priv_data)
     }
     memset(pbuf, 0, buf_len);
     buf_len = ble_dev_info_make(ble, pbuf, buf_len);
+    if (buf_len == 0) {
+        PR_ERR("ble_dev_info_make failed");
+        tal_free(pbuf);
+        return OPRT_COM_ERROR;
+    }
     // tuya_ble_raw_print("ble dev info:", 8, pbuf, buf_len);
 
     ble_packet_t resp;
@@ -878,10 +930,18 @@ void ble_session_system_process(ble_packet_t *packet, void *priv_data)
     switch (packet->type) {
 
     case FRM_QRY_DEV_INFO_REQ:
+        if (packet->len < 2 || packet->data == NULL) {
+            PR_ERR("ble dev info req invalid len %d", packet->len);
+            break;
+        }
         TUYA_CALL_ERR_LOG(ble_dev_info_req(packet, priv_data));
         break;
 
     case FRM_PAIR_REQ:
+        if (packet->len < BLE_ID_LEN || packet->data == NULL) {
+            PR_ERR("ble pair req invalid len %d", packet->len);
+            break;
+        }
         TUYA_CALL_ERR_LOG(ble_pair_req(packet, priv_data));
         break;
 
@@ -972,6 +1032,18 @@ static void tal_ble_event_callback(void *data)
         memset(ble->pair_rand, 0x00, sizeof(ble->pair_rand));
         tal_sw_timer_stop(ble->pair_timer);
         ble->is_paired = false;
+        ble_frame_packet_len_set(TUYA_BLE_AIR_FRAME_MAX);
+        if (ble->packet_recv && ble->packet_recv->trsmitr) {
+            uint8_t *default_subpkg = (uint8_t *)tal_malloc(TUYA_BLE_AIR_FRAME_MAX);
+            if (default_subpkg) {
+                memset(default_subpkg, 0, TUYA_BLE_AIR_FRAME_MAX);
+                if (ble->packet_recv->trsmitr->subpkg) {
+                    tal_free(ble->packet_recv->trsmitr->subpkg);
+                }
+                ble->packet_recv->trsmitr->subpkg = default_subpkg;
+            }
+        }
+        ble_channel_reset();
         if (!tuya_iot_is_connected()) {
             ble_adv_update(ble);
         }
@@ -995,6 +1067,13 @@ static void tal_ble_event_callback(void *data)
                 break;
             }
             PR_DEBUG("ble recv req type 0x%04x", packet.type);
+            if (!ble->is_paired && packet.type != FRM_QRY_DEV_INFO_REQ && packet.type != FRM_PAIR_REQ) {
+                PR_ERR("ble cmd 0x%04x requires pairing", packet.type);
+                if (packet.data) {
+                    tal_free(packet.data);
+                }
+                break;
+            }
             int i;
             for (i = 0; i < BLE_SESSION_MAX; i++) {
                 if (ble->session[i].function) {

--- a/src/tuya_cloud_service/ble/ble_mgr.c
+++ b/src/tuya_cloud_service/ble/ble_mgr.c
@@ -1033,14 +1033,25 @@ static void tal_ble_event_callback(void *data)
         tal_sw_timer_stop(ble->pair_timer);
         ble->is_paired = false;
         ble_frame_packet_len_set(TUYA_BLE_AIR_FRAME_MAX);
-        if (ble->packet_recv && ble->packet_recv->trsmitr) {
-            uint8_t *default_subpkg = (uint8_t *)tal_malloc(TUYA_BLE_AIR_FRAME_MAX);
-            if (default_subpkg) {
-                memset(default_subpkg, 0, TUYA_BLE_AIR_FRAME_MAX);
-                if (ble->packet_recv->trsmitr->subpkg) {
-                    tal_free(ble->packet_recv->trsmitr->subpkg);
+        if (ble->packet_recv) {
+            ble->packet_recv->raw_len = 0;
+            memset(ble->packet_recv->raw_buf, 0, sizeof(ble->packet_recv->raw_buf));
+            if (ble->packet_recv->trsmitr) {
+                uint8_t *default_subpkg = (uint8_t *)tal_malloc(TUYA_BLE_AIR_FRAME_MAX);
+                if (default_subpkg) {
+                    memset(default_subpkg, 0, TUYA_BLE_AIR_FRAME_MAX);
+                    if (ble->packet_recv->trsmitr->subpkg) {
+                        tal_free(ble->packet_recv->trsmitr->subpkg);
+                    }
+                    ble->packet_recv->trsmitr->subpkg = default_subpkg;
                 }
-                ble->packet_recv->trsmitr->subpkg = default_subpkg;
+                ble->packet_recv->trsmitr->total = 0;
+                ble->packet_recv->trsmitr->version = 0;
+                ble->packet_recv->trsmitr->seq = 0;
+                ble->packet_recv->trsmitr->pkg_trsmitr_cnt = 0;
+                ble->packet_recv->trsmitr->subpkg_num = 0;
+                ble->packet_recv->trsmitr->subpkg_len = 0;
+                ble->packet_recv->trsmitr->pkg_desc = BLE_FRAME_PKG_INIT;
             }
         }
         ble_channel_reset();

--- a/src/tuya_cloud_service/ble/ble_mgr.c
+++ b/src/tuya_cloud_service/ble/ble_mgr.c
@@ -224,9 +224,14 @@ static uint32_t ble_packet_trsmitr(ble_packet_recv_t *packet_recv, uint8_t *buf,
     uint32_t subpkg_len = 0;
 
     int rt = ble_frame_trsmitr_recv_pkg_decode(packet_recv->trsmitr, buf, len);
+    if (OPRT_SVC_BT_API_TRSMITR_DUPLICATE == rt) {
+        PR_DEBUG("ble recv duplicate subpacket %d, ignored", packet_recv->trsmitr->subpkg_num);
+        return OPRT_SVC_BT_API_TRSMITR_CONTINUE;
+    }
     if (OPRT_OK != rt && OPRT_SVC_BT_API_TRSMITR_CONTINUE != rt) { // decode error
         packet_recv->raw_len = 0;
         memset(packet_recv->raw_buf, 0, sizeof(packet_recv->raw_buf));
+        packet_recv->trsmitr->pkg_desc = BLE_FRAME_PKG_INIT;
         return rt;
     }
     // For the first packet of a multi-packet transmission, or in the case of a
@@ -243,13 +248,17 @@ static uint32_t ble_packet_trsmitr(ble_packet_recv_t *packet_recv, uint8_t *buf,
              subpkg_len, packet_recv->raw_len + subpkg_len);
 
     if ((packet_recv->raw_len + subpkg_len) <= TUYA_BLE_AIR_FRAME_MAX) {
-        memcpy(packet_recv->raw_buf + packet_recv->raw_len, ble_frame_subpacket_get(packet_recv->trsmitr), subpkg_len);
+        if (subpkg_len > 0) {
+            memcpy(packet_recv->raw_buf + packet_recv->raw_len, ble_frame_subpacket_get(packet_recv->trsmitr), subpkg_len);
+            packet_recv->raw_len += subpkg_len;
+        }
     } else {
-        rt = OPRT_INVALID_PARM;
         PR_ERR("ble unpack overflow, desc:%d, pack_len:%d", packet_recv->trsmitr->pkg_desc, subpkg_len);
+        packet_recv->raw_len = 0;
+        memset(packet_recv->raw_buf, 0, sizeof(packet_recv->raw_buf));
+        packet_recv->trsmitr->pkg_desc = BLE_FRAME_PKG_INIT;
+        return OPRT_INVALID_PARM;
     }
-
-    packet_recv->raw_len += subpkg_len;
 
     return rt;
 }
@@ -875,16 +884,11 @@ static int ble_dev_info_req(ble_packet_t *req, void *priv_data)
         return OPRT_MALLOC_FAILED;
     }
     memset(new_subpkg, 0, pkg_len);
-    if (trsmitr->subpkg) {
-        tal_free(trsmitr->subpkg);
-    }
-    trsmitr->subpkg = new_subpkg;
-    ble_frame_packet_len_set(pkg_len);
-    PR_NOTICE("ble dev info: state:%d, pkg_len:%d", *ble->is_bound, ble_frame_packet_len_get());
 
     pbuf = (uint8_t *)tal_malloc(buf_len);
     if (NULL == pbuf) {
         PR_ERR("malloc err");
+        tal_free(new_subpkg);
         return OPRT_MALLOC_FAILED;
     }
     memset(pbuf, 0, buf_len);
@@ -892,8 +896,18 @@ static int ble_dev_info_req(ble_packet_t *req, void *priv_data)
     if (buf_len == 0) {
         PR_ERR("ble_dev_info_make failed");
         tal_free(pbuf);
+        tal_free(new_subpkg);
         return OPRT_COM_ERROR;
     }
+
+    // All resources prepared successfully, commit changes atomically
+    if (trsmitr->subpkg) {
+        tal_free(trsmitr->subpkg);
+    }
+    trsmitr->subpkg = new_subpkg;
+    trsmitr->subpkg_capacity = pkg_len;
+    ble_frame_packet_len_set(pkg_len);
+    PR_NOTICE("ble dev info: state:%d, pkg_len:%d", *ble->is_bound, ble_frame_packet_len_get());
     // tuya_ble_raw_print("ble dev info:", 8, pbuf, buf_len);
 
     ble_packet_t resp;
@@ -1032,7 +1046,6 @@ static void tal_ble_event_callback(void *data)
         memset(ble->pair_rand, 0x00, sizeof(ble->pair_rand));
         tal_sw_timer_stop(ble->pair_timer);
         ble->is_paired = false;
-        ble_frame_packet_len_set(TUYA_BLE_AIR_FRAME_MAX);
         if (ble->packet_recv) {
             ble->packet_recv->raw_len = 0;
             memset(ble->packet_recv->raw_buf, 0, sizeof(ble->packet_recv->raw_buf));
@@ -1044,6 +1057,13 @@ static void tal_ble_event_callback(void *data)
                         tal_free(ble->packet_recv->trsmitr->subpkg);
                     }
                     ble->packet_recv->trsmitr->subpkg = default_subpkg;
+                    ble->packet_recv->trsmitr->subpkg_capacity = TUYA_BLE_AIR_FRAME_MAX;
+                    ble_frame_packet_len_set(TUYA_BLE_AIR_FRAME_MAX);
+                } else {
+                    PR_ERR("malloc default_subpkg failed on disconnect!");
+                    if (ble->packet_recv->trsmitr->subpkg_capacity > 0) {
+                        ble_frame_packet_len_set(ble->packet_recv->trsmitr->subpkg_capacity);
+                    }
                 }
                 ble->packet_recv->trsmitr->total = 0;
                 ble->packet_recv->trsmitr->version = 0;
@@ -1129,6 +1149,7 @@ int tuya_ble_deinit(void)
         return OPRT_OK;
     }
     PR_NOTICE("ble deinit...");
+    ble_channel_reset();
     if (ble->pair_timer) {
         tal_sw_timer_delete(ble->pair_timer);
     }

--- a/src/tuya_cloud_service/ble/ble_netcfg.c
+++ b/src/tuya_cloud_service/ble/ble_netcfg.c
@@ -34,9 +34,16 @@ extern int tuya_ble_adv_update(void);
 static void __handle_net_cfg(void *data, void *user_data)
 {
     uint8_t result = 0;
-    uint8_t resp[5];
+    uint8_t resp[5] = {0};
+    cJSON *json = NULL;
 
-    cJSON *json = cJSON_Parse(data);
+    if (NULL == data) {
+        PR_ERR("netcfg data is NULL");
+        result = (uint8_t)OPRT_INVALID_PARM;
+        goto __exit;
+    }
+
+    json = cJSON_Parse(data);
     if (NULL == json) {
         PR_ERR(" json parse error.");
         result = (uint8_t)OPRT_CJSON_PARSE_ERR;
@@ -111,6 +118,7 @@ __exit:
     if (json) {
         cJSON_Delete(json);
     }
+    resp[0] = 0x00;
     resp[1] = 0x00; // for blt timer task, set as not subpacket, not response
     resp[2] = 0x00;
     resp[3] = FRM_DATA_TRANS_SUBCMD_BT_NETCFG;

--- a/src/tuya_cloud_service/ble/ble_trsmitr.c
+++ b/src/tuya_cloud_service/ble/ble_trsmitr.c
@@ -47,13 +47,15 @@ ble_frame_trsmitr_t *ble_frame_trsmitr_create(void)
         return NULL;
     }
     memset(trsmitr, 0, sizeof(ble_frame_trsmitr_t));
-    trsmitr->subpkg = (uint8_t *)tal_malloc(ble_frame_packet_len_get());
+    uint16_t packet_len = ble_frame_packet_len_get();
+    trsmitr->subpkg = (uint8_t *)tal_malloc(packet_len);
     if (trsmitr->subpkg == NULL) {
-        PR_ERR("malloc err:%d", ble_frame_packet_len_get());
+        PR_ERR("malloc err:%d", packet_len);
         tal_free(trsmitr);
         return NULL;
     }
-    memset(trsmitr->subpkg, 0, ble_frame_packet_len_get());
+    trsmitr->subpkg_capacity = packet_len;
+    memset(trsmitr->subpkg, 0, packet_len);
 
     return trsmitr;
 }
@@ -150,7 +152,7 @@ static ble_frame_seq_t ble_frame_seq_get(void)
 int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned char version, unsigned char *buf,
                                       unsigned int len)
 {
-    if (((void *)0) == trsmitr) {
+    if (NULL == trsmitr || NULL == buf || NULL == trsmitr->subpkg || 0 == len) {
         return OPRT_INVALID_PARM;
     }
 
@@ -162,15 +164,14 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
         trsmitr->pkg_trsmitr_cnt = 0;
     }
 
-    if (NULL == buf || NULL == trsmitr || NULL == trsmitr->subpkg) {
-        return OPRT_INVALID_PARM;
-    }
-
     if (trsmitr->subpkg_num >= 0x10000000 || len >= 0x10000000) {
         return OPRT_COM_ERROR;
     }
 
     uint16_t pkg_max_len = ble_frame_packet_len_get();
+    if (trsmitr->subpkg_capacity > 0 && pkg_max_len > trsmitr->subpkg_capacity) {
+        pkg_max_len = (uint16_t)trsmitr->subpkg_capacity;
+    }
     if (pkg_max_len < 10) {
         return OPRT_COM_ERROR;
     }
@@ -285,21 +286,22 @@ int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned cha
         return OPRT_INVALID_PARM;
     }
 
-    if (BLE_FRAME_PKG_INIT == trsmitr->pkg_desc) {
-        trsmitr->total = 0;
-        trsmitr->version = 0;
-        trsmitr->seq = 0;
-        trsmitr->pkg_trsmitr_cnt = 0;
+    uint16_t pkg_max_len = ble_frame_packet_len_get();
+    if (trsmitr->subpkg_capacity > 0 && pkg_max_len > trsmitr->subpkg_capacity) {
+        pkg_max_len = (uint16_t)trsmitr->subpkg_capacity;
+    }
+    if (raw_data_len > pkg_max_len) {
+        return OPRT_INVALID_PARM;
     }
 
     unsigned char sunpkg_offset = 0;
-    // package code
-    // subpackage num decode
     int i;
     unsigned int multiplier = 1;
-    unsigned char digit;
+    unsigned char digit = 0;
     ble_frame_subpkg_num_t subpkg_num = 0;
-    // Package number
+    bool subpkg_num_terminated = false;
+
+    // Decode subpackage number (varint, max 4 bytes)
     for (i = 0; i < 4; i++) {
         if (sunpkg_offset >= raw_data_len) {
             return OPRT_INVALID_PARM;
@@ -309,88 +311,101 @@ int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned cha
         multiplier *= 0x80;
 
         if (0 == (digit & 0x80)) {
+            subpkg_num_terminated = true;
             break;
         }
     }
-    // PR_DEBUG("subpkg_num:%d, trsmitr->subpkg_num:%d", subpkg_num,
-    // trsmitr->subpkg_num);
-    if (0 == subpkg_num) {
-        trsmitr->total = 0;
-        trsmitr->version = 0;
-        trsmitr->seq = 0;
-        trsmitr->pkg_trsmitr_cnt = 0;
-        trsmitr->pkg_desc = BLE_FRAME_PKG_FIRST;
+    if (!subpkg_num_terminated) {
+        return OPRT_INVALID_PARM;
+    }
+
+    // State machine check
+    uint8_t cur_desc = trsmitr->pkg_desc;
+    if (BLE_FRAME_PKG_INIT == cur_desc || BLE_FRAME_PKG_END == cur_desc) {
+        // Must start with subpacket 0
+        if (0 != subpkg_num) {
+            return OPRT_SVC_BT_API_TRSMITR_ERROR;
+        }
     } else {
-        trsmitr->pkg_desc = BLE_FRAME_PKG_MIDDLE;
-    }
-
-    if (trsmitr->subpkg_num >= 0x10000000) {
-        return OPRT_COM_ERROR;
-    }
-    // is receive the subpackage num valid?
-    if (trsmitr->pkg_desc != BLE_FRAME_PKG_FIRST) {
-        if (subpkg_num < trsmitr->subpkg_num) {
-            return OPRT_SVC_BT_API_TRSMITR_ERROR;
-        } else if (subpkg_num == trsmitr->subpkg_num) {
-            return OPRT_SVC_BT_API_TRSMITR_CONTINUE;
+        // In the middle of an active reception (FIRST or MIDDLE)
+        if (subpkg_num == trsmitr->subpkg_num) {
+            // Duplicate subpacket
+            trsmitr->subpkg_len = 0;
+            return OPRT_SVC_BT_API_TRSMITR_DUPLICATE;
         }
-
-        if (subpkg_num - trsmitr->subpkg_num > 1) {
+        if (subpkg_num != trsmitr->subpkg_num + 1) {
+            // Out of order or gap
             return OPRT_SVC_BT_API_TRSMITR_ERROR;
         }
     }
-    trsmitr->subpkg_num = subpkg_num;
 
-    if (0 == trsmitr->subpkg_num) {
-        // frame len decode
+    uint32_t next_total = trsmitr->total;
+    uint8_t next_version = trsmitr->version;
+    uint8_t next_seq = trsmitr->seq;
+    uint32_t next_pkg_cnt = trsmitr->pkg_trsmitr_cnt;
+
+    if (0 == subpkg_num) {
+        next_total = 0;
+        next_pkg_cnt = 0;
         multiplier = 1;
+        bool total_terminated = false;
         for (i = 0; i < 4; i++) {
             if (sunpkg_offset >= raw_data_len) {
                 return OPRT_INVALID_PARM;
             }
             digit = raw_data[sunpkg_offset++];
-            trsmitr->total += (digit & 0x7f) * multiplier;
+            next_total += (digit & 0x7f) * multiplier;
             multiplier *= 0x80;
 
             if (0 == (digit & 0x80)) {
+                total_terminated = true;
                 break;
             }
         }
+        if (!total_terminated) {
+            return OPRT_INVALID_PARM;
+        }
 
-        if (trsmitr->total >= 0x10000000) {
-            return OPRT_COM_ERROR;
+        if (next_total == 0 || next_total > TUYA_BLE_AIR_FRAME_MAX) {
+            return OPRT_INVALID_PARM;
         }
 
         if (sunpkg_offset >= raw_data_len) {
             return OPRT_INVALID_PARM;
         }
         // frame type and frame seq decode
-        trsmitr->version = (raw_data[sunpkg_offset] & BLE_FRAME_VERSION_OFFSET) >> 4;
-        trsmitr->seq = raw_data[sunpkg_offset++] & BLE_FRAME_SEQ_OFFSET;
+        next_version = (raw_data[sunpkg_offset] & BLE_FRAME_VERSION_OFFSET) >> 4;
+        next_seq = raw_data[sunpkg_offset++] & BLE_FRAME_SEQ_OFFSET;
     }
 
     if (sunpkg_offset >= raw_data_len) {
         return OPRT_INVALID_PARM;
     }
+
     uint16_t recv_data = raw_data_len - sunpkg_offset;
-    uint16_t pkg_max_len = ble_frame_packet_len_get();
     if (recv_data > pkg_max_len) {
         recv_data = pkg_max_len;
     }
     uint32_t remain_data =
-        (trsmitr->total > trsmitr->pkg_trsmitr_cnt) ? (trsmitr->total - trsmitr->pkg_trsmitr_cnt) : 0;
+        (next_total > next_pkg_cnt) ? (next_total - next_pkg_cnt) : 0;
     if (remain_data < recv_data) {
         recv_data = (uint16_t)remain_data;
     }
 
-    // decode data cp to transmitter subpackage buf
+    // All checks passed! Now commit to trsmitr atomically
+    trsmitr->subpkg_num = subpkg_num;
+    trsmitr->total = next_total;
+    trsmitr->version = next_version;
+    trsmitr->seq = next_seq;
+
     if (recv_data > 0) {
         memcpy(trsmitr->subpkg, &raw_data[sunpkg_offset], recv_data);
     }
     trsmitr->subpkg_len = recv_data;
-    trsmitr->pkg_trsmitr_cnt += recv_data;
+    trsmitr->pkg_trsmitr_cnt = next_pkg_cnt + recv_data;
 
     if (trsmitr->pkg_trsmitr_cnt < trsmitr->total) {
+        trsmitr->pkg_desc = (0 == subpkg_num) ? BLE_FRAME_PKG_FIRST : BLE_FRAME_PKG_MIDDLE;
         return OPRT_SVC_BT_API_TRSMITR_CONTINUE;
     }
     trsmitr->pkg_desc = BLE_FRAME_PKG_END;

--- a/src/tuya_cloud_service/ble/ble_trsmitr.c
+++ b/src/tuya_cloud_service/ble/ble_trsmitr.c
@@ -162,7 +162,16 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
         trsmitr->pkg_trsmitr_cnt = 0;
     }
 
+    if (NULL == buf || NULL == trsmitr || NULL == trsmitr->subpkg) {
+        return OPRT_INVALID_PARM;
+    }
+
     if (trsmitr->subpkg_num >= 0x10000000 || len >= 0x10000000) {
+        return OPRT_COM_ERROR;
+    }
+
+    uint16_t pkg_max_len = ble_frame_packet_len_get();
+    if (pkg_max_len < 10) {
         return OPRT_COM_ERROR;
     }
 
@@ -174,6 +183,9 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
     unsigned int tmp = 0;
     tmp = trsmitr->subpkg_num;
     for (i = 0; i < 4; i++) {
+        if (sunpkg_offset >= pkg_max_len) {
+            return OPRT_COM_ERROR;
+        }
         trsmitr->subpkg[sunpkg_offset] = tmp % 0x80;
         if ((tmp / 0x80)) {
             trsmitr->subpkg[sunpkg_offset] |= 0x80;
@@ -190,6 +202,9 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
         // frame len encode
         tmp = len;
         for (i = 0; i < 4; i++) {
+            if (sunpkg_offset >= pkg_max_len) {
+                return OPRT_COM_ERROR;
+            }
             trsmitr->subpkg[sunpkg_offset] = tmp % 0x80;
             if ((tmp / 0x80)) {
                 trsmitr->subpkg[sunpkg_offset] |= 0x80;
@@ -201,17 +216,24 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
             }
         }
 
+        if (sunpkg_offset >= pkg_max_len) {
+            return OPRT_COM_ERROR;
+        }
         // frame type and frame seq
         trsmitr->subpkg[sunpkg_offset++] = (trsmitr->version << 0x04) | (trsmitr->seq & 0x0f);
     }
 
     // frame data transfer
-    uint16_t send_data = (ble_frame_packet_len_get() - sunpkg_offset);
-    if ((len - trsmitr->pkg_trsmitr_cnt) < send_data) {
-        send_data = len - trsmitr->pkg_trsmitr_cnt;
+    if (sunpkg_offset >= pkg_max_len) {
+        return OPRT_COM_ERROR;
+    }
+    uint16_t send_data = pkg_max_len - sunpkg_offset;
+    uint32_t remain_data = (len > trsmitr->pkg_trsmitr_cnt) ? (len - trsmitr->pkg_trsmitr_cnt) : 0;
+    if (remain_data < send_data) {
+        send_data = (uint16_t)remain_data;
     }
 
-    PR_TRACE("pkg max len:%d, sunpkg_offset:%d, send_data:%d", ble_frame_packet_len_get(), sunpkg_offset, send_data);
+    PR_TRACE("pkg max len:%d, sunpkg_offset:%d, send_data:%d", pkg_max_len, sunpkg_offset, send_data);
 
     memcpy(&(trsmitr->subpkg[sunpkg_offset]), buf + trsmitr->pkg_trsmitr_cnt, send_data);
     trsmitr->subpkg_len = sunpkg_offset + send_data;
@@ -229,6 +251,7 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
     }
 
     trsmitr->pkg_desc = BLE_FRAME_PKG_END;
+
     return OPRT_OK;
 }
 
@@ -257,7 +280,8 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
  */
 int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned char *raw_data, uint16_t raw_data_len)
 {
-    if (NULL == raw_data || NULL == trsmitr) { //|| (raw_data_len > ble_frame_packet_len_get())
+    if (NULL == raw_data || NULL == trsmitr || NULL == trsmitr->subpkg || 0 == raw_data_len ||
+        raw_data_len > ble_frame_packet_len_get()) {
         return OPRT_INVALID_PARM;
     }
 
@@ -277,6 +301,9 @@ int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned cha
     ble_frame_subpkg_num_t subpkg_num = 0;
     // Package number
     for (i = 0; i < 4; i++) {
+        if (sunpkg_offset >= raw_data_len) {
+            return OPRT_INVALID_PARM;
+        }
         digit = raw_data[sunpkg_offset++];
         subpkg_num += (digit & 0x7f) * multiplier;
         multiplier *= 0x80;
@@ -318,6 +345,9 @@ int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned cha
         // frame len decode
         multiplier = 1;
         for (i = 0; i < 4; i++) {
+            if (sunpkg_offset >= raw_data_len) {
+                return OPRT_INVALID_PARM;
+            }
             digit = raw_data[sunpkg_offset++];
             trsmitr->total += (digit & 0x7f) * multiplier;
             multiplier *= 0x80;
@@ -331,12 +361,22 @@ int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned cha
             return OPRT_COM_ERROR;
         }
 
+        if (sunpkg_offset >= raw_data_len) {
+            return OPRT_INVALID_PARM;
+        }
         // frame type and frame seq decode
         trsmitr->version = (raw_data[sunpkg_offset] & BLE_FRAME_VERSION_OFFSET) >> 4;
         trsmitr->seq = raw_data[sunpkg_offset++] & BLE_FRAME_SEQ_OFFSET;
     }
 
+    if (sunpkg_offset >= raw_data_len) {
+        return OPRT_INVALID_PARM;
+    }
     uint16_t recv_data = raw_data_len - sunpkg_offset;
+    uint16_t pkg_max_len = ble_frame_packet_len_get();
+    if (recv_data > pkg_max_len) {
+        recv_data = pkg_max_len;
+    }
     if ((trsmitr->total - trsmitr->pkg_trsmitr_cnt) < recv_data) {
         recv_data = trsmitr->total - trsmitr->pkg_trsmitr_cnt;
     }

--- a/src/tuya_cloud_service/ble/ble_trsmitr.c
+++ b/src/tuya_cloud_service/ble/ble_trsmitr.c
@@ -377,12 +377,16 @@ int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned cha
     if (recv_data > pkg_max_len) {
         recv_data = pkg_max_len;
     }
-    if ((trsmitr->total - trsmitr->pkg_trsmitr_cnt) < recv_data) {
-        recv_data = trsmitr->total - trsmitr->pkg_trsmitr_cnt;
+    uint32_t remain_data =
+        (trsmitr->total > trsmitr->pkg_trsmitr_cnt) ? (trsmitr->total - trsmitr->pkg_trsmitr_cnt) : 0;
+    if (remain_data < recv_data) {
+        recv_data = (uint16_t)remain_data;
     }
 
     // decode data cp to transmitter subpackage buf
-    memcpy(trsmitr->subpkg, &raw_data[sunpkg_offset], recv_data);
+    if (recv_data > 0) {
+        memcpy(trsmitr->subpkg, &raw_data[sunpkg_offset], recv_data);
+    }
     trsmitr->subpkg_len = recv_data;
     trsmitr->pkg_trsmitr_cnt += recv_data;
 

--- a/src/tuya_cloud_service/ble/ble_trsmitr.h
+++ b/src/tuya_cloud_service/ble/ble_trsmitr.h
@@ -52,6 +52,10 @@ typedef uint8_t ble_frame_pkg_desc_t;
 #define BLE_FRAME_PKG_MIDDLE 2 // frame package middle
 #define BLE_FRAME_PKG_END    3 // frame package end
 
+#ifndef OPRT_SVC_BT_API_TRSMITR_DUPLICATE
+#define OPRT_SVC_BT_API_TRSMITR_DUPLICATE (-0x1f03)
+#endif
+
 // frame transmitter process
 typedef struct {
     ble_frame_total_t total;           // 4 bytes, total data length, excluding header
@@ -63,6 +67,7 @@ typedef struct {
     uint32_t pkg_trsmitr_cnt;          // package process count, number of bytes sent
     ble_frame_subpkg_len_t subpkg_len; // 1 byte, data length in the current subpackage
     uint8_t *subpkg;
+    uint32_t subpkg_capacity;          // allocated capacity of subpkg buffer
 } ble_frame_trsmitr_t;
 
 /***********************************************************

--- a/src/tuya_cloud_service/schema/dp_schema.c
+++ b/src/tuya_cloud_service/schema/dp_schema.c
@@ -146,6 +146,10 @@ dp_node_t *dp_node_find(dp_schema_t *schema, int id)
     int i;
     dp_node_t *dpnode = NULL;
 
+    if (NULL == schema) {
+        return NULL;
+    }
+
     for (i = 0; i < schema->num; i++) {
         if (schema->node[i].desc.id == id) {
             dpnode = &schema->node[i];


### PR DESCRIPTION
## Summary

This pull request resolves 14 security vulnerabilities (TO-01 through TO-16) identified in the TuyaOpen BLE protocol stack (`tuya_cloud_service/ble`) and DP schema module (`tuya_cloud_service/schema`).

All fixes have been validated through static code review, firmware compilation, and real hardware testing on a connected T5-Core board (including full BLE provisioning, cloud activation, and over-the-air BLE attack mitigation testing).

---

### Key Fixes

- **TO-01 & TO-04 (Pre-auth Plaintext Bypass & Unauthenticated Factory Reset)**:
  - Reject `ENCRYPTION_MODE_NONE` frames in `ble_packet_recv` when the device is bound.
  - Enforce pairing check (`is_paired`), bound state (`*ble->is_bound`), and encryption mode in `ble_unbind_req`.
  - Enforce pairing gate in `tal_ble_event_callback` to reject unauthorized commands before pairing.

- **TO-02 & TO-08 & TO-09 (Channel Buffer Overflow, Unbounded Varint, Unterminated JSON Buffer)**:
  - Replaced unsafe static variables in `ble_session_channel_process` with explicit bounds-managed buffer.
  - Clamped max channel packet length to `TUYA_BLE_AIR_FRAME_MAX` and strictly checked remaining space per subpacket.
  - Added `max_len` check to `__extract_packet_len` to prevent unbounded varint parsing loops.
  - Added explicit NUL termination (`s_channel_buffer[total_len] = 0`) before passing data to `ble_channel_process` / `cJSON_Parse`.
  - Added `ble_channel_reset()` on disconnect and error paths to prevent memory leakage across connections.

- **TO-03 & TO-14 (Transmitter Send/Receive Unsigned Underflow & Buffer Overflow)**:
  - Restored input parameter checks and max packet length validation in `ble_frame_trsmitr_recv_pkg_decode` and `ble_frame_trsmitr_send_pkg_encode`.
  - Guarded against unsigned subtraction underflow: `remain_data = (len > cnt) ? (len - cnt) : 0`.
  - Strictly bound subpacket offset and data length within `ble_frame_packet_len_get()`.

- **TO-05 & TO-15 (Null Dereference on Zero-Length Payload & Pair Request)**:
  - Added minimum length (`packet->len >= 2`) and NULL pointer checks for `FRM_QRY_DEV_INFO_REQ` and `FRM_PAIR_REQ`.
  - Added NULL pointer checks in `ble_pair_req`, `ble_dev_info_req`, and `ble_dp_req`.

- **TO-06 & TO-07 (DP Length Underflow & Enum Out-of-Bounds Pointer Read)**:
  - Validated DP request length `req->len >= 5` before offset operations in `ble_dp_req`.
  - Added boundary validation for `DT_ENUM`: verified `val < dpnode->prop.prop_enum.cnt` and `pp_enum != NULL`.
  - Added bounds and NULL checks for `DT_RAW`, `DT_BOOL`, `DT_BITMAP`, `DT_VALUE`.

- **TO-10 (Uninitialized Stack Byte Leak)**:
  - Zero-initialized `resp[5]` buffer in `ble_netcfg.c` and explicitly set `resp[0] = 0x00` on all exit paths.

- **TO-11 & TO-13 (Peer-Controlled Reassembly Buffer Size & Dev Info Make Overflow)**:
  - Clamped peer-specified `pkg_len` in `ble_dev_info_req` to valid range `[20, TUYA_BLE_AIR_FRAME_MAX]`.
  - Reordered buffer reallocation safely (allocate new buffer first before freeing old buffer).
  - Added `buflen < BLE_DEV_INFO_MAX_LEN` check in `ble_dev_info_make`.
  - Reset frame packet length and trsmitr subpkg to default on BLE disconnect.

- **TO-16 (dp_node_find Null Schema Dereference)**:
  - Added `if (NULL == schema) return NULL;` in `dp_node_find`.

---

### Hardware Verification

- **Target**: T5-Core (`TUYA_T5AI_BOARD`, BK7258)
- **Compilation**: Clean build with 0 errors (`switch_demo`, `ble_peripher`).
- **Functional Validation**: Flashed to hardware, successfully paired via mobile Tuya Smart App over BLE, and activated with cloud service.
- **Vulnerability Defense Testing**: Tested via over-the-air BLE packets using external laptop Bluetooth; verified unauthorized plaintext unbind, zero-length crash, and underflow packets are correctly rejected without device reset or panic.