### PR TITLE
fix(ble): remediate BLE parser vulnerabilities

### DIFF
--- a/src/tuya_cloud_service/ble/ble_channel.c
+++ b/src/tuya_cloud_service/ble/ble_channel.c
@@ -1,28 +1,20 @@
 /**
- * @file ble_channel.C
- * @brief Implementation of BLE channel management for data transmission and
- * reception. This file provides functionalities for BLE channel creation,
- * deletion, data packet processing, and response handling in a BLE
- * communication scenario. It supports large data packet handling by splitting
- * data into subpackets, managing subpacket transmission, and reassembling
- * received subpackets.
+ * @file ble_channel.c
+ * @brief BLE transparent-channel framing and reassembly.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
- *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  */
 
 #include "tal_api.h"
 #include "ble_channel.h"
 
-#define SUBPACKET_RECV_ALL_DONE         0
-#define SUBPACKET_RECV_ONE_AND_NEXT     1
-#define SUBPACKET_RECV_ERROR_RESTART    2
-#define SUBPACKET_RECV_ERROR_DISCONNECT 3
+#define SUBPACKET_RECV_ALL_DONE     0
+#define SUBPACKET_RECV_ONE_AND_NEXT 1
 
 #pragma pack(1)
-typedef struct subpacketAck {
+typedef struct {
     uint16_t flag;
-    uint8_t status;
+    uint8_t  status;
     uint16_t curSubpacketNo;
     uint16_t cursubpacketLen;
     uint32_t receivedLen;
@@ -36,312 +28,284 @@ typedef struct {
     uint32_t subpack_no;
     uint32_t subpack_sent;
     uint32_t subpack_len;
-} ble_channel_mgr_t;
+} ble_channel_tx_t;
 
-static ble_channel_mgr_t s_ble_channel_mgr = {0}; // APP downlink channel transparent transmission
+typedef struct {
+    uint8_t *buffer;
+    uint32_t capacity;
+    uint32_t received;
+    uint32_t expected_no;
+} ble_channel_rx_t;
 
 typedef struct {
     ble_channel_fn_t function;
-    void *priv_data;
+    void            *priv_data;
 } ble_channel_t;
 
-static ble_channel_t s_ble_channel[BLE_CHANNEL_MAX];
+static ble_channel_tx_t s_ble_channel_tx;
+static ble_channel_rx_t s_ble_channel_rx;
+static ble_channel_t    s_ble_channel[BLE_CHANNEL_MAX];
 
-/**
- * @brief Adds a BLE channel.
- *
- * This function adds a BLE channel of the specified type with the provided
- * function and private data.
- *
- * @param type The type of the BLE channel.
- * @param fn The function to be associated with the BLE channel.
- * @param priv_data The private data to be associated with the BLE channel.
- * @return Returns OPRT_OK if the BLE channel was added successfully, or
- * OPRT_INVALID_PARM if the type is invalid.
- */
+static int ble_channel_varint_decode(const uint8_t *data, uint32_t data_len, uint32_t *offset, uint32_t *value)
+{
+    uint32_t result = 0;
+
+    for (uint8_t i = 0; i < 4; i++) {
+        if (*offset >= data_len) {
+            return OPRT_INVALID_PARM;
+        }
+        uint8_t digit = data[(*offset)++];
+        result |= (uint32_t)(digit & 0x7f) << (i * 7);
+        if ((digit & 0x80) == 0) {
+            *value = result;
+            return OPRT_OK;
+        }
+    }
+
+    return OPRT_INVALID_PARM;
+}
+
+static int ble_channel_varint_encode(uint32_t value, uint8_t *data, uint32_t capacity, uint32_t *offset)
+{
+    do {
+        if (*offset >= capacity) {
+            return OPRT_INVALID_PARM;
+        }
+        uint8_t digit = value & 0x7f;
+        value >>= 7;
+        data[(*offset)++] = digit | (value != 0 ? 0x80 : 0);
+    } while (value != 0);
+
+    return OPRT_OK;
+}
+
+void ble_channel_rx_reset(void)
+{
+    if (s_ble_channel_rx.buffer != NULL) {
+        tal_free(s_ble_channel_rx.buffer);
+    }
+    memset(&s_ble_channel_rx, 0, sizeof(s_ble_channel_rx));
+}
+
+void ble_channel_tx_reset(void)
+{
+    if (s_ble_channel_tx.rsp_data != NULL) {
+        tal_free(s_ble_channel_tx.rsp_data);
+    }
+    memset(&s_ble_channel_tx, 0, sizeof(s_ble_channel_tx));
+}
+
+void ble_channel_reset(void)
+{
+    ble_channel_rx_reset();
+    ble_channel_tx_reset();
+}
+
 int ble_channel_add(ble_channel_type_t type, ble_channel_fn_t fn, void *priv_data)
 {
-    ble_channel_t *channel = s_ble_channel;
-
-    if (type < BLE_CHANNEL_MAX) {
-        channel[type].function = fn;
-        channel[type].priv_data = priv_data;
-
-        return OPRT_OK;
+    if (type >= BLE_CHANNEL_MAX) {
+        return OPRT_INVALID_PARM;
     }
-
-    return OPRT_INVALID_PARM;
+    s_ble_channel[type].function  = fn;
+    s_ble_channel[type].priv_data = priv_data;
+    return OPRT_OK;
 }
 
-/**
- * @brief Deletes a BLE channel.
- *
- * This function deletes a BLE channel of the specified type.
- *
- * @param type The type of the BLE channel to delete.
- * @return Returns OPRT_OK if the channel is successfully deleted, or
- * OPRT_INVALID_PARM if the type is invalid.
- */
 int ble_channel_del(ble_channel_type_t type)
 {
-    ble_channel_t *channel = s_ble_channel;
-
-    if (type < BLE_CHANNEL_MAX) {
-        channel[type].function = NULL;
-        channel[type].priv_data = NULL;
-        return OPRT_OK;
+    if (type >= BLE_CHANNEL_MAX) {
+        return OPRT_INVALID_PARM;
     }
-
-    return OPRT_INVALID_PARM;
+    s_ble_channel[type].function  = NULL;
+    s_ble_channel[type].priv_data = NULL;
+    return OPRT_OK;
 }
 
-static void ble_channel_process(void *data)
+static void ble_channel_process(uint8_t *data, uint32_t len)
 {
-    uint8_t *user_data = (uint8_t *)data;
-    uint16_t type = (user_data[0] << 8) | (user_data[1]);
-
-    ble_channel_t *channel = s_ble_channel;
-
-    PR_DEBUG("ble channel type:%x", type);
-
-    if (type < BLE_CHANNEL_MAX) {
-        if (channel[type].function) {
-            channel[type].function(user_data + 2, channel[type].priv_data);
-        } else {
-            PR_DEBUG("ble channel not add :%x", type);
-        }
-    }
-}
-
-uint32_t __extract_packet_len(uint8_t *raw_data, uint32_t *pNum)
-{
-    uint8_t i = 0;
-    uint32_t multiplier = 1;
-    uint8_t digit;
-    uint8_t offset = 0;
-    uint32_t num = 0;
-
-    for (i = 0; i < 4; i++) {
-        digit = raw_data[offset++];
-        num += (digit & 0x7f) * multiplier;
-        multiplier *= 0x80;
-
-        if (0 == (digit & 0x80)) {
-            break;
-        }
-    }
-    *pNum = num;
-
-    return offset;
-}
-
-static void __response_to_app_by_subpack(uint16_t type)
-{
-    uint32_t subpack_sent = s_ble_channel_mgr.subpack_sent;
-    uint32_t subpack_len = s_ble_channel_mgr.subpack_len;
-    uint32_t subpack_no = s_ble_channel_mgr.subpack_no;
-    uint16_t pkg_offset = 0;
-    uint16_t pkg_data_len = 0;
-    uint8_t *pkg_buff = NULL;
-
-    if (NULL == s_ble_channel_mgr.rsp_data) {
-        PR_ERR("no subpack data");
+    if (data == NULL || len < 2) {
         return;
     }
 
-    pkg_buff = tal_malloc(TUYA_BLE_TRANS_DATA_SUBPACK_LEN);
-    if (NULL == pkg_buff) {
-        PR_ERR("malloc error in __get_timer_data");
-        return;
+    uint16_t type = ((uint16_t)data[0] << 8) | data[1];
+    if (type < BLE_CHANNEL_MAX && s_ble_channel[type].function != NULL) {
+        s_ble_channel[type].function(data + 2, s_ble_channel[type].priv_data);
     }
-    memset(pkg_buff, 0, TUYA_BLE_TRANS_DATA_SUBPACK_LEN);
-
-    if (subpack_sent < subpack_len) { // has subpack data not sent yet
-        pkg_offset = 0;
-        pkg_buff[pkg_offset++] = 0x00;
-        pkg_buff[pkg_offset++] = 0x03; // flag: set as need subpacket, need response
-        pkg_buff[pkg_offset++] = subpack_no;
-        if (0 == subpack_no) {
-            uint32_t tmp = subpack_len;
-            for (int i = 0; i < 4; i++) {
-                pkg_buff[pkg_offset] = tmp % 0x80;
-                if (tmp / 0x80) {
-                    pkg_buff[pkg_offset] |= 0x80;
-                }
-                pkg_offset++;
-                tmp /= 0x80;
-                if (0 == tmp) {
-                    break;
-                }
-            }
-            pkg_buff[pkg_offset++] = (TUYA_BLE_PROTOCOL_VERSION_HIGN << 0x04);
-        }
-
-        pkg_data_len = TUYA_BLE_TRANS_DATA_SUBPACK_LEN - pkg_offset;
-        if ((subpack_len - subpack_sent) < pkg_data_len) {
-            pkg_data_len = subpack_len - subpack_sent;
-        }
-        memcpy(pkg_buff + pkg_offset, s_ble_channel_mgr.subpack_data + subpack_sent, pkg_data_len);
-        tuya_ble_send(type, 0, pkg_buff, pkg_offset + pkg_data_len);
-
-        s_ble_channel_mgr.subpack_sent += pkg_data_len;
-        s_ble_channel_mgr.subpack_no++;
-    }
-
-    tal_free(pkg_buff);
 }
 
-/**
- * @brief Sends a response to the app by subpack.
- *
- * This function is responsible for sending a response to the app by subpack.
- * It takes the type, data, and length of the response as parameters.
- * The function first checks if there is any previous subpack data, and if so,
- * it frees the memory. Then, it initializes the s_ble_channel_mgr structure,
- * sets the response data, subpack data, and subpack length. Finally, it prints
- * a debug message and calls the __response_to_app_by_subpack() function.
- *
- * @param type The type of the response.
- * @param data The data of the response.
- * @param len The length of the response.
- */
+static void ble_channel_response_by_subpack(uint16_t type)
+{
+    if (s_ble_channel_tx.rsp_data == NULL || s_ble_channel_tx.subpack_sent > s_ble_channel_tx.subpack_len ||
+        (s_ble_channel_tx.subpack_sent == s_ble_channel_tx.subpack_len && s_ble_channel_tx.subpack_no != 0)) {
+        return;
+    }
+
+    uint8_t *packet = tal_malloc(TUYA_BLE_TRANS_DATA_SUBPACK_LEN);
+    if (packet == NULL) {
+        return;
+    }
+
+    uint32_t offset  = 0;
+    packet[offset++] = 0;
+    packet[offset++] = 3;
+    if (ble_channel_varint_encode(s_ble_channel_tx.subpack_no, packet, TUYA_BLE_TRANS_DATA_SUBPACK_LEN, &offset) !=
+        OPRT_OK) {
+        tal_free(packet);
+        return;
+    }
+    if (s_ble_channel_tx.subpack_no == 0) {
+        if (ble_channel_varint_encode(s_ble_channel_tx.subpack_len, packet, TUYA_BLE_TRANS_DATA_SUBPACK_LEN, &offset) !=
+                OPRT_OK ||
+            offset >= TUYA_BLE_TRANS_DATA_SUBPACK_LEN) {
+            tal_free(packet);
+            return;
+        }
+        packet[offset++] = TUYA_BLE_PROTOCOL_VERSION_HIGN << 4;
+    }
+
+    uint32_t remaining = s_ble_channel_tx.subpack_len - s_ble_channel_tx.subpack_sent;
+    uint32_t available = TUYA_BLE_TRANS_DATA_SUBPACK_LEN - offset;
+    uint32_t data_len  = remaining < available ? remaining : available;
+    if (data_len != 0) {
+        memcpy(packet + offset, s_ble_channel_tx.subpack_data + s_ble_channel_tx.subpack_sent, data_len);
+    }
+    tuya_ble_send(type, 0, packet, offset + data_len);
+    s_ble_channel_tx.subpack_sent += data_len;
+    s_ble_channel_tx.subpack_no++;
+    tal_free(packet);
+}
+
 void ble_channle_ack(uint16_t type, uint8_t *data, uint32_t len)
 {
-    if (s_ble_channel_mgr.rsp_data) {
-        PR_ERR("pre subpack data overwrite!");
-        tal_free(s_ble_channel_mgr.rsp_data);
-    }
-
-    memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
-    s_ble_channel_mgr.rsp_data = data;
-    s_ble_channel_mgr.subpack_data = data + 2;
-    s_ble_channel_mgr.subpack_len = len - 2;
-
-    PR_DEBUG("start to send subpack cmd:%x, subcmd:%x", type, data[3]);
-    __response_to_app_by_subpack(type);
-}
-
-/**
- * @brief Processes the BLE session channel.
- *
- * This function is responsible for processing the BLE session channel based on
- * the received BLE packet. It handles both downlink and uplink transparent
- * requests and transparent specific requests. For downlink requests, it checks
- * if the packet is a subpacket or not and processes accordingly. For uplink
- * requests, it handles different status codes and takes appropriate actions.
- *
- * @param req The BLE packet to be processed.
- * @param user_data User data associated with the BLE packet.
- */
-void ble_session_channel_process(ble_packet_t *req, void *user_data)
-{
-    if (!(req->type == FRM_DOWNLINK_TRANSPARENT_REQ || req->type == FRM_DOWNLINK_TRANSPARENT_SPEC_REQ ||
-          req->type == FRM_UPLINK_TRANSPARENT_REQ || req->type == FRM_UPLINK_TRANSPARENT_SPEC_REQ)) {
+    if (data == NULL || len < 2 || len - 2 >= 0x10000000) {
+        if (data != NULL) {
+            tal_free(data);
+        }
         return;
     }
 
-    uint8_t *pRawData = req->data;
-    uint16_t pRawLen = req->len;
+    ble_channel_tx_reset();
+    s_ble_channel_tx.rsp_data     = data;
+    s_ble_channel_tx.subpack_data = data + 2;
+    s_ble_channel_tx.subpack_len  = len - 2;
+    ble_channel_response_by_subpack(type);
+}
 
-    if (FRM_DOWNLINK_TRANSPARENT_REQ == req->type || FRM_DOWNLINK_TRANSPARENT_SPEC_REQ == req->type) {
-        tuya_ble_raw_print("recv_downlink_frame", 16, pRawData, pRawLen);
+static void ble_channel_ack_send(ble_packet_t *req, uint32_t subpacket_no, uint32_t subpacket_len, uint8_t status)
+{
+    ble_channel_ack_t ack = {0};
+    ack.flag              = ((uint16_t)req->data[1] << 8) | req->data[0];
+    ack.status            = status;
+    ack.curSubpacketNo    = subpacket_no;
+    ack.cursubpacketLen   = subpacket_len;
+    ack.receivedLen       = s_ble_channel_rx.received;
+    ack.totalLen          = s_ble_channel_rx.capacity;
+    tuya_ble_send(req->type, req->sn, (uint8_t *)&ack, sizeof(ack));
+}
 
-        // [0~1]: flag
-        // bit0: 0 - not need response, 1 - need response
-        // bit1: 0 - not subpacket, 1 - subpacket
-        if (pRawData[1] & 0x02) { // subpacket process
-            uint32_t offset = 0;
-            uint32_t curSubpacketNo = 0;
-            uint32_t curSubpacketLen = 0;
-            static uint32_t totalLen = 0; // all subpackets data length
-            static uint8_t *pBuffer = NULL;
-            static uint32_t receivedLen = 0; // already received subpackets data length
+static void ble_channel_downlink_process(ble_packet_t *req)
+{
+    uint8_t *data = req->data;
+    uint32_t len  = req->len;
+    if (len < 2) {
+        ble_channel_rx_reset();
+        return;
+    }
 
-            if (pRawData[2] == 0) { // first subpacket
-                offset = 3;         // skip flag and first subpacket no, total 3B
-                totalLen = 0;
-                receivedLen = 0;
-                offset += __extract_packet_len(pRawData + offset,
-                                               &totalLen); // parse all subpackets data length
-                PR_DEBUG("first downlink subpacket, totalLen:%u", totalLen);
-
-                if (pBuffer) {
-                    tal_free(pBuffer);
-                    pBuffer = NULL;
-                }
-                pBuffer = tal_malloc(totalLen);
-                if (NULL == pBuffer) {
-                    PR_ERR("malloc error for pBuffer in __handle_bt_timer_task");
-                    return;
-                }
-
-                offset += 1; // skip version and reserve, total 1B
-                curSubpacketLen = pRawLen - offset;
-                memcpy(pBuffer + receivedLen, pRawData + offset, curSubpacketLen);
-                receivedLen += curSubpacketLen;
-                curSubpacketNo = 0;
-            } else { // subsequent subpackets
-                if (NULL == pBuffer) {
-                    PR_ERR("malloc error for pBuffer in __handle_bt_timer_task");
-                    return;
-                }
-
-                offset = 2; // skip flag, total 2B
-                offset += __extract_packet_len(pRawData + offset,
-                                               &curSubpacketNo); // parse current subpacket no
-                curSubpacketLen = pRawLen - offset;
-                memcpy(pBuffer + receivedLen, pRawData + offset, curSubpacketLen);
-                receivedLen += curSubpacketLen;
-            }
-
-            PR_DEBUG("rece downlink subpacket, curSubpacketNo:%u, "
-                     "curSubpacketLen:%u, receivedLen:%u, totalLen:%u",
-                     curSubpacketNo, curSubpacketLen, receivedLen, totalLen);
-
-            ble_channel_ack_t *pAck = tal_malloc(sizeof(ble_channel_ack_t));
-            if (pAck == NULL) {
-                PR_ERR("malloc error for pAck in __handle_bt_timer_task");
-                tal_free(pBuffer);
-                pBuffer = NULL;
-                return;
-            }
-            pAck->flag = (pRawData[1] << 8) | pRawData[0];
-            pAck->curSubpacketNo = curSubpacketNo;
-            pAck->cursubpacketLen = curSubpacketLen;
-            pAck->receivedLen = receivedLen;
-            pAck->totalLen = totalLen;
-
-            if (receivedLen < totalLen) {
-                pAck->status = SUBPACKET_RECV_ONE_AND_NEXT;
-                tuya_ble_send(req->type, req->sn, (uint8_t *)pAck, sizeof(ble_channel_ack_t));
-                tal_free(pAck);
-            } else {
-                pAck->status = SUBPACKET_RECV_ALL_DONE;
-                tuya_ble_send(req->type, req->sn, (uint8_t *)pAck, sizeof(ble_channel_ack_t));
-                tal_free(pAck);
-
-                tuya_ble_raw_print("recv_donwlink_cmd", 16, pBuffer, totalLen);
-                ble_channel_process(pBuffer);
-            }
-        } else { // not subpacket process
-            tuya_ble_raw_print("recv_downlink_cmd", 16, pRawData, pRawLen);
-            ble_channel_process(pRawData + 2);
+    if ((data[1] & 0x02) == 0) {
+        if (len >= 4) {
+            ble_channel_process(data + 2, len - 2);
         }
-    } else if (FRM_UPLINK_TRANSPARENT_REQ == req->type || FRM_UPLINK_TRANSPARENT_SPEC_REQ == req->type) {
-        tuya_ble_raw_print("recv_uplink_frame", 16, pRawData, pRawLen);
-        uint8_t status = pRawData[2];
-        if (status == 0) { // complete subpack send
-            if (s_ble_channel_mgr.rsp_data) {
-                tal_free(s_ble_channel_mgr.rsp_data);
-            }
-            memset(&s_ble_channel_mgr, 0, sizeof(s_ble_channel_mgr));
-        } else if (status == 1) { // continue subpack send
-            __response_to_app_by_subpack(req->type);
-        } else if (status == 2) { // restart subpack send
-            s_ble_channel_mgr.subpack_no = 0;
-            s_ble_channel_mgr.subpack_sent = 0;
-            __response_to_app_by_subpack(req->type);
-        } else {
+        return;
+    }
+
+    uint32_t offset       = 2;
+    uint32_t subpacket_no = 0;
+    if (ble_channel_varint_decode(data, len, &offset, &subpacket_no) != OPRT_OK) {
+        ble_channel_rx_reset();
+        return;
+    }
+
+    uint32_t fragment_len;
+    if (subpacket_no == 0) {
+        uint32_t total_len = 0;
+        if (s_ble_channel_rx.buffer != NULL || ble_channel_varint_decode(data, len, &offset, &total_len) != OPRT_OK ||
+            total_len < 2 || total_len > TUYA_BLE_AIR_FRAME_MAX || offset >= len) {
+            ble_channel_rx_reset();
+            return;
         }
+        offset++;
+        fragment_len = len - offset;
+        if (fragment_len > total_len) {
+            ble_channel_rx_reset();
+            return;
+        }
+        s_ble_channel_rx.buffer = tal_malloc(total_len + 1);
+        if (s_ble_channel_rx.buffer == NULL) {
+            ble_channel_rx_reset();
+            return;
+        }
+        s_ble_channel_rx.capacity    = total_len;
+        s_ble_channel_rx.expected_no = 1;
+    } else {
+        if (s_ble_channel_rx.buffer == NULL || subpacket_no != s_ble_channel_rx.expected_no) {
+            ble_channel_rx_reset();
+            return;
+        }
+        fragment_len = len - offset;
+        if (s_ble_channel_rx.received > s_ble_channel_rx.capacity ||
+            fragment_len > s_ble_channel_rx.capacity - s_ble_channel_rx.received) {
+            ble_channel_rx_reset();
+            return;
+        }
+        s_ble_channel_rx.expected_no++;
+    }
+
+    if (fragment_len != 0) {
+        memcpy(s_ble_channel_rx.buffer + s_ble_channel_rx.received, data + offset, fragment_len);
+    } else if (s_ble_channel_rx.received < s_ble_channel_rx.capacity && subpacket_no != 0) {
+        ble_channel_rx_reset();
+        return;
+    }
+    s_ble_channel_rx.received += fragment_len;
+    s_ble_channel_rx.buffer[s_ble_channel_rx.received] = '\0';
+
+    if (s_ble_channel_rx.received < s_ble_channel_rx.capacity) {
+        ble_channel_ack_send(req, subpacket_no, fragment_len, SUBPACKET_RECV_ONE_AND_NEXT);
+        return;
+    }
+
+    ble_channel_ack_send(req, subpacket_no, fragment_len, SUBPACKET_RECV_ALL_DONE);
+    ble_channel_process(s_ble_channel_rx.buffer, s_ble_channel_rx.capacity);
+    ble_channel_rx_reset();
+}
+
+void ble_session_channel_process(ble_packet_t *req, void *user_data)
+{
+    (void)user_data;
+    if (req == NULL || req->data == NULL) {
+        return;
+    }
+
+    if (req->type == FRM_DOWNLINK_TRANSPARENT_REQ || req->type == FRM_DOWNLINK_TRANSPARENT_SPEC_REQ) {
+        ble_channel_downlink_process(req);
+        return;
+    }
+    if (req->type != FRM_UPLINK_TRANSPARENT_REQ && req->type != FRM_UPLINK_TRANSPARENT_SPEC_REQ) {
+        return;
+    }
+    if (req->len < 3) {
+        return;
+    }
+
+    uint8_t status = req->data[2];
+    if (status == 0) {
+        ble_channel_tx_reset();
+    } else if (status == 1) {
+        ble_channel_response_by_subpack(req->type);
+    } else if (status == 2) {
+        s_ble_channel_tx.subpack_no   = 0;
+        s_ble_channel_tx.subpack_sent = 0;
+        ble_channel_response_by_subpack(req->type);
     }
 }

--- a/src/tuya_cloud_service/ble/ble_channel.h
+++ b/src/tuya_cloud_service/ble/ble_channel.h
@@ -13,7 +13,7 @@
  * efficient and organized data transmission mechanisms.
  *
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -60,6 +60,9 @@ int ble_channel_del(ble_channel_type_t type);
  * channel.
  */
 void ble_session_channel_process(ble_packet_t *req, void *priv_data);
+void ble_channel_rx_reset(void);
+void ble_channel_tx_reset(void);
+void ble_channel_reset(void);
 
 #ifdef __cplusplus
 }

--- a/src/tuya_cloud_service/ble/ble_dp.c
+++ b/src/tuya_cloud_service/ble/ble_dp.c
@@ -7,7 +7,7 @@
  * booleans, and various sized integers. Additionally, it includes utilities for
  * managing memory and ensuring data integrity during the process.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -19,6 +19,7 @@
 #include "tuya_protocol.h"
 #include "tuya_iot_dp.h"
 #include "mix_method.h"
+#include "ble_dp_validate.h"
 
 // dp type describe
 typedef uint8_t dp_type;
@@ -45,10 +46,10 @@ typedef uint8_t dp_type;
 
 typedef struct s_klv_node {
     struct s_klv_node *next;
-    uint8_t id;
-    dp_type type;
-    uint16_t len;
-    uint8_t *data;
+    uint8_t            id;
+    dp_type            type;
+    uint16_t           len;
+    uint8_t           *data;
 } klv_node_s;
 
 void tuya_change_bt_dp_tlv(dp_type type, void *data, uint16_t *len)
@@ -57,22 +58,22 @@ void tuya_change_bt_dp_tlv(dp_type type, void *data, uint16_t *len)
         uint32_t enum_value = *(uint32_t *)data;
         if (enum_value <= 0xff) {
             uint8_t enum_byte = *(uint32_t *)data;
-            *len = 1;
+            *len              = 1;
             memcpy(data, &enum_byte, *len);
         } else if (enum_value <= 0xffff) {
             uint16_t enum_short = *(uint32_t *)data;
-            *len = 2;
-            enum_short = UNI_HTONS(enum_short);
+            *len                = 2;
+            enum_short          = UNI_HTONS(enum_short);
             memcpy(data, &enum_short, *len);
         } else {
             uint32_t enum_int = *(uint32_t *)data;
-            *len = 4;
-            enum_int = UNI_HTONL(enum_int);
+            *len              = 4;
+            enum_int          = UNI_HTONL(enum_int);
             memcpy(data, &enum_int, *len);
         }
     } else if (DT_BOOL == type) {
         uint8_t bool_value = *(uint32_t *)data;
-        *len = 1;
+        *len               = 1;
         memcpy(data, &bool_value, *len);
     }
 }
@@ -83,7 +84,7 @@ void free_klv_list(klv_node_s *list)
         return;
     }
 
-    klv_node_s *node = list;
+    klv_node_s *node      = list;
     klv_node_s *next_node = NULL;
 
     do {
@@ -98,7 +99,7 @@ void free_klv_list(klv_node_s *list)
 klv_node_s *make_klv_list(klv_node_s *list, uint8_t id, dp_type type, void *data, uint16_t len)
 {
     klv_node_s *node;
-    void *p_data = NULL;
+    void       *p_data = NULL;
 
     if (NULL == data || type >= DT_LMT) {
         PR_ERR("input invalid");
@@ -107,7 +108,7 @@ klv_node_s *make_klv_list(klv_node_s *list, uint8_t id, dp_type type, void *data
 
     if (DT_VALUE == type && DT_VALUE_LEN != len) {
         goto err_ret;
-    } else if (DT_BITMAP == type && len > DT_BITMAP_MAX) {
+    } else if (DT_BITMAP == type && !ble_dp_klv_length_valid(DT_BITMAP, len)) {
         goto err_ret;
     } else if (DT_BOOL == type && DT_BOOL_LEN != len) {
         goto err_ret;
@@ -137,18 +138,16 @@ klv_node_s *make_klv_list(klv_node_s *list, uint8_t id, dp_type type, void *data
             goto err_ret;
         }
     }
-    node->id = id;
-    node->len = len;
+    node->id   = id;
+    node->len  = len;
     node->type = type;
 
     if (DT_VALUE == type || DT_BITMAP == type) {
-        // change to big-end
-        unsigned int tmp = *(unsigned int *)p_data;
-        // unsigned char shift = 0;
-        node->data[0] = (tmp >> 24) & 0xff;
-        node->data[1] = (tmp >> 16) & 0xff;
-        node->data[2] = (tmp >> 8) & 0xff;
-        node->data[3] = (tmp >> 0) & 0xff;
+        if (!ble_dp_scalar_to_big_endian(p_data, len, node->data)) {
+            tal_free((uint8_t *)node->data);
+            tal_free((uint8_t *)node);
+            goto err_ret;
+        }
     } else {
         // Enumerations and BOOL have been converted to byte order in tuya_change_bt_dp_tlv. You can copy them directly
         if (len > 0) {
@@ -174,8 +173,8 @@ OPERATE_RET klvlist_2_data(klv_node_s *list, uint8_t **data, uint32_t *len, uint
         return OPRT_INVALID_PARM;
     }
 
-    static uint32_t sn = 1;
-    klv_node_s *node = list;
+    static uint32_t sn   = 1;
+    klv_node_s     *node = list;
     // type: 1: 4.x protocol dp report
     uint8_t type = 1;
 
@@ -240,7 +239,7 @@ OPERATE_RET klvlist_2_data(klv_node_s *list, uint8_t **data, uint32_t *len, uint
         offset += node->len;
         node = node->next;
     }
-    *len = offset;
+    *len  = offset;
     *data = mk_data;
 
     // if(ty_get_sync_rpt_flag() && (FALSE == query)){
@@ -261,9 +260,9 @@ OPERATE_RET data_2_klvlist(uint8_t *data, uint32_t len, klv_node_s **list)
 
     tuya_ble_raw_print("data_2_klvlist", 16, data, len);
 
-    unsigned int offset = 0;
-    klv_node_s *klv_list = NULL;
-    klv_node_s *node = NULL;
+    unsigned int offset   = 0;
+    klv_node_s  *klv_list = NULL;
+    klv_node_s  *node     = NULL;
     do {
         // not full klv
         if (type == 1) {
@@ -285,13 +284,19 @@ OPERATE_RET data_2_klvlist(uint8_t *data, uint32_t len, klv_node_s **list)
         }
         memset(node, 0, sizeof(klv_node_s));
 
-        node->id = data[offset++];
+        node->id   = data[offset++];
         node->type = data[offset++];
         if (1 == type) {
             node->len = data[offset++];
             node->len = (node->len << 8) + data[offset++];
         } else {
             node->len = data[offset++];
+        }
+
+        if (!ble_dp_klv_length_valid(node->type, node->len)) {
+            tal_free((uint8_t *)node);
+            free_klv_list(klv_list);
+            return OPRT_COM_ERROR;
         }
 
         if (node->len > 0) {
@@ -315,7 +320,7 @@ OPERATE_RET data_2_klvlist(uint8_t *data, uint32_t len, klv_node_s **list)
 
         offset += node->len;
         node->next = klv_list;
-        klv_list = node;
+        klv_list   = node;
     } while (offset < len);
 
     if (NULL == klv_list) {
@@ -330,8 +335,12 @@ static OPERATE_RET __result_code_resp(uint16_t type, uint32_t ack_sn, uint8_t re
     return tuya_ble_send(type, ack_sn, &result_code, 1);
 }
 
-static OPERATE_RET __result_code_resp_v4(uint16_t type, uint32_t ack_sn, uint8_t *data, uint8_t result_code)
+static OPERATE_RET __result_code_resp_v4(uint16_t type, uint32_t ack_sn, const uint8_t *data, uint16_t len,
+                                         uint8_t result_code)
 {
+    if (!ble_dp_v4_payload_valid(data, len)) {
+        return OPRT_INVALID_PARM;
+    }
     uint8_t data_code[6] = {0}; // version(1byte)+R_SN(4byte)+STATE(1byte)
     memcpy(data_code, data, 5);
     data_code[5] = result_code;
@@ -352,43 +361,43 @@ static OPERATE_RET __dp_data_report_data(uint16_t type, uint8_t *p_data, uint32_
 klv_node_s *__make_obj_dp_klv_list(dp_rept_in_t *dpin)
 {
     klv_node_s *p_node = NULL;
-    int index = 0;
+    int         index  = 0;
 
     for (index = 0; index < dpin->dpscnt; index++) {
-        dp_obj_t *p_dp = dpin->dps + index;
-        dp_type new_type = 0;
-        void *new_data = NULL;
-        uint16_t new_len = 0;
+        dp_obj_t *p_dp     = dpin->dps + index;
+        dp_type   new_type = 0;
+        void     *new_data = NULL;
+        uint16_t  new_len  = 0;
 
         switch (p_dp->type) {
         case PROP_BOOL: {
             new_type = DT_BOOL;
             new_data = &(p_dp->value.dp_bool);
-            new_len = DT_BOOL_LEN;
+            new_len  = DT_BOOL_LEN;
             break;
         }
         case PROP_VALUE: {
             new_type = DT_VALUE;
             new_data = &(p_dp->value.dp_value);
-            new_len = DT_VALUE_LEN;
+            new_len  = DT_VALUE_LEN;
             break;
         }
         case PROP_STR: {
             new_type = DT_STRING;
             new_data = p_dp->value.dp_str;
-            new_len = strlen(p_dp->value.dp_str);
+            new_len  = strlen(p_dp->value.dp_str);
             break;
         }
         case PROP_ENUM: {
             new_type = DT_ENUM;
             new_data = &(p_dp->value.dp_enum);
-            new_len = DT_ENUM_LEN;
+            new_len  = DT_ENUM_LEN;
             break;
         }
         case PROP_BITMAP: {
             new_type = DT_BITMAP;
             new_data = &(p_dp->value.dp_bitmap);
-            new_len = DT_BITMAP_MAX;
+            new_len  = DT_BITMAP_MAX;
             break;
         }
         default:
@@ -403,38 +412,38 @@ klv_node_s *__make_obj_dp_klv_list(dp_rept_in_t *dpin)
 
 OPERATE_RET ty_bt_dp_data_report(klv_node_s *p_node, uint32_t time_stamp)
 {
-    OPERATE_RET ret = OPRT_OK;
-    uint16_t type = FRM_STAT_REPORT;
+    OPERATE_RET ret  = OPRT_OK;
+    uint16_t    type = FRM_STAT_REPORT;
 
     if (NULL == p_node) {
         return OPRT_INVALID_PARM;
     }
 
-    time_stamp = UNI_HTONL(time_stamp);
+    time_stamp             = UNI_HTONL(time_stamp);
     uint32_t *p_time_stamp = (time_stamp > 0) ? &time_stamp : NULL;
-    uint8_t *p_new_data = NULL;
-    uint32_t new_data_len = 0;
+    uint8_t  *p_new_data   = NULL;
+    uint32_t  new_data_len = 0;
     klvlist_2_data(p_node, &p_new_data, &new_data_len, p_time_stamp, FALSE, 0);
     free_klv_list(p_node);
 
     type = (NULL != p_time_stamp) ? FRM_DP_STAT_REPORT_WITH_TIME_V4 : FRM_DP_STAT_REPORT_V4;
-    ret = __dp_data_report_data(type, p_new_data, new_data_len);
+    ret  = __dp_data_report_data(type, p_new_data, new_data_len);
     tal_free(p_new_data);
     return ret;
 }
 
 static __attribute__((unused)) klv_node_s *__get_response_query_dp_data(const uint8_t *dpid, const uint8_t num)
 {
-    uint16_t i;
-    klv_node_s *p_node = NULL;
+    uint16_t     i;
+    klv_node_s  *p_node = NULL;
     dp_schema_t *schema = tuya_iot_client_get()->schema;
 
     tal_mutex_lock(schema->mutex);
     for (i = 0; i < num; i++) {
-        int id = dpid[i];
-        dp_type new_type = 0;
-        void *new_data = NULL;
-        uint16_t new_len = 0;
+        int      id       = dpid[i];
+        dp_type  new_type = 0;
+        void    *new_data = NULL;
+        uint16_t new_len  = 0;
 
         dp_node_t *dpnode = dp_node_find(schema, id);
 
@@ -453,27 +462,27 @@ static __attribute__((unused)) klv_node_s *__get_response_query_dp_data(const ui
         case PROP_BOOL: {
             new_type = DT_BOOL;
             new_data = &(dpnode->prop.prop_bool.value);
-            new_len = DT_BOOL_LEN;
+            new_len  = DT_BOOL_LEN;
         } break;
         case PROP_VALUE: {
             new_type = DT_VALUE;
             new_data = &(dpnode->prop.prop_int.value);
-            new_len = DT_VALUE_LEN;
+            new_len  = DT_VALUE_LEN;
         } break;
         case PROP_STR: {
             new_type = DT_STRING;
             new_data = dpnode->prop.prop_str.value;
-            new_len = strlen(dpnode->prop.prop_str.value);
+            new_len  = strlen(dpnode->prop.prop_str.value);
         } break;
         case PROP_ENUM: {
             new_type = DT_ENUM;
             new_data = &(dpnode->prop.prop_enum.value);
-            new_len = DT_ENUM_LEN;
+            new_len  = DT_ENUM_LEN;
         } break;
         case PROP_BITMAP: {
             new_type = DT_BITMAP;
             new_data = &(dpnode->prop.prop_bitmap.value);
-            new_len = DT_BITMAP_MAX;
+            new_len  = DT_BITMAP_MAX;
         } break;
         default:
             break;
@@ -498,8 +507,8 @@ uint32_t __dp_get_time_stamp(dp_obj_t *dp_data, const uint32_t cnt)
 
 static int ble_dp_report(const dp_rept_in_t *dpin)
 {
-    klv_node_s *p_node = NULL;
-    uint32_t time_stamp = 0;
+    klv_node_s *p_node     = NULL;
+    uint32_t    time_stamp = 0;
 
     if (NULL == dpin) {
         return OPRT_INVALID_PARM;
@@ -508,7 +517,7 @@ static int ble_dp_report(const dp_rept_in_t *dpin)
     switch (dpin->rept_type) {
     case T_OBJ_REPT: {
         time_stamp = __dp_get_time_stamp(dpin->dps, dpin->dpscnt);
-        p_node = __make_obj_dp_klv_list((dp_rept_in_t *)dpin);
+        p_node     = __make_obj_dp_klv_list((dp_rept_in_t *)dpin);
         break;
     }
     case T_STAT_REPT: {
@@ -528,15 +537,24 @@ static int ble_dp_report(const dp_rept_in_t *dpin)
 
 static int ble_dp_req(ble_packet_t *req, void *priv_data)
 {
-    uint8_t *data = NULL;
-    uint16_t len = 0;
+    (void)priv_data;
+    uint8_t           *data   = NULL;
+    uint16_t           len    = 0;
+    tuya_iot_client_t *client = tuya_iot_client_get();
+
+    if (req == NULL || req->data == NULL || client == NULL ||
+        !ble_dp_client_ready(client->is_activated, client->schema)) {
+        return OPRT_INVALID_PARM;
+    }
 
     tuya_ble_raw_print("ble dp", 32, req->data, req->len);
 
     if (req->type == FRM_DP_CMD_SEND_V4) {
-        __result_code_resp_v4(FRM_DP_CMD_SEND_V4, req->sn, req->data, 0);
+        if (!ble_dp_v4_payload_valid(req->data, req->len)) {
+            return OPRT_INVALID_PARM;
+        }
         data = req->data + 5;
-        len = req->len - 5;
+        len  = req->len - 5;
     } else {
         return OPRT_NOT_SUPPORTED;
     }
@@ -554,7 +572,7 @@ static int ble_dp_req(ble_packet_t *req, void *priv_data)
     }
     cJSON_AddItemToObject(p_root, "dps", p_dps);
     klv_node_s *list = NULL;
-    int ret = data_2_klvlist(data, len, &list);
+    int         ret  = data_2_klvlist(data, len, &list);
     if (OPRT_OK != ret) {
         PR_ERR("parse err:%d", ret);
         cJSON_Delete(p_root);
@@ -580,21 +598,43 @@ static int ble_dp_req(ble_packet_t *req, void *priv_data)
             break;
         }
         case DT_BOOL: {
+            if (p_tmp->data == NULL || p_tmp->len != 1) {
+                ret = OPRT_INVALID_PARM;
+                goto EXIT;
+            }
             cJSON_AddBoolToObject(p_dps, dp_id_str, *(p_tmp->data));
             break;
         }
         case DT_BITMAP:
         case DT_VALUE: {
-            int val = (p_tmp->data[0] << 24) + (p_tmp->data[1] << 16) + (p_tmp->data[2] << 8) + (p_tmp->data[3] << 0);
+            if (p_tmp->data == NULL || (p_tmp->type == DT_VALUE && p_tmp->len != 4) ||
+                (p_tmp->type == DT_BITMAP && !(p_tmp->len == 1 || p_tmp->len == 2 || p_tmp->len == 4))) {
+                ret = OPRT_INVALID_PARM;
+                goto EXIT;
+            }
+            uint32_t val = 0;
+            for (uint16_t i = 0; i < p_tmp->len; i++) {
+                val = (val << 8) | p_tmp->data[i];
+            }
             cJSON_AddNumberToObject(p_dps, dp_id_str, val);
             break;
         }
         case DT_ENUM: {
-            int val = p_tmp->data[0];
-            dp_node_t *dpnode = dp_node_find(tuya_iot_client_get()->schema, p_tmp->id);
-            if (NULL == dpnode) {
+            if (p_tmp->data == NULL || !(p_tmp->len == 1 || p_tmp->len == 2 || p_tmp->len == 4)) {
+                ret = OPRT_INVALID_PARM;
+                goto EXIT;
+            }
+            uint32_t val = 0;
+            for (uint16_t i = 0; i < p_tmp->len; i++) {
+                val = (val << 8) | p_tmp->data[i];
+            }
+            dp_node_t *dpnode = dp_node_find(client->schema, p_tmp->id);
+            if (dpnode == NULL || dpnode->desc.type != T_OBJ || dpnode->desc.prop_tp != PROP_ENUM ||
+                dpnode->prop.prop_enum.cnt <= 0 ||
+                !ble_dp_enum_value_valid(val, dpnode->prop.prop_enum.cnt, dpnode->prop.prop_enum.pp_enum)) {
                 PR_ERR("invalid dp id[%d]", p_tmp->id);
-                break;
+                ret = OPRT_INVALID_PARM;
+                goto EXIT;
             }
             cJSON_AddStringToObject(p_dps, dp_id_str, dpnode->prop.prop_enum.pp_enum[val]);
             break;
@@ -613,11 +653,13 @@ static int ble_dp_req(ble_packet_t *req, void *priv_data)
         }
         p_tmp = p_tmp->next;
     }
-    ret = tuya_iot_dp_parse(tuya_iot_client_get(), DP_CMD_BT, p_root);
+    ret = tuya_iot_dp_parse(client, DP_CMD_BT, p_root);
     free_klv_list(list);
     if (ret != OPRT_OK) {
         cJSON_Delete(p_root);
+        return ret;
     }
+    __result_code_resp_v4(FRM_DP_CMD_SEND_V4, req->sn, req->data, req->len, 0);
     return ret;
 
 EXIT:
@@ -628,13 +670,17 @@ EXIT:
 
 static int ble_dp_query(ble_packet_t *req, void *priv_data)
 {
+    tuya_iot_client_t *client = tuya_iot_client_get();
+    if (req == NULL || client == NULL || !ble_dp_client_ready(client->is_activated, client->schema)) {
+        return OPRT_INVALID_PARM;
+    }
     PR_NOTICE("ble recv dp query");
     tuya_ble_raw_print("ble dp query", 16, req->data, req->len);
     __result_code_resp(req->type, req->sn, 0);
 
-    dp_schema_t *schema = dp_schema_find(tuya_iot_client_get()->activate.devid);
+    dp_schema_t *schema = dp_schema_find(client->activate.devid);
 
-    int i;
+    int         i;
     klv_node_s *p_node = NULL;
     if (schema == NULL) {
         PR_DEBUG("schema null");
@@ -651,39 +697,39 @@ static int ble_dp_query(ble_packet_t *req, void *priv_data)
             // do nth for now
         }
         if (dpnode->desc.type == T_OBJ) {
-            dp_type new_type = 0;
-            void *new_data = NULL;
-            uint16_t new_len = 0;
+            dp_type  new_type = 0;
+            void    *new_data = NULL;
+            uint16_t new_len  = 0;
 
             switch (dpnode->desc.prop_tp) {
             case PROP_BOOL: {
                 new_type = DT_BOOL;
                 new_data = &(dpnode->prop.prop_bool.value);
-                new_len = DT_BOOL_LEN;
+                new_len  = DT_BOOL_LEN;
             } break;
             case PROP_VALUE: {
                 new_type = DT_VALUE;
                 new_data = &(dpnode->prop.prop_int.value);
-                new_len = DT_VALUE_LEN;
+                new_len  = DT_VALUE_LEN;
             } break;
             case PROP_STR: {
                 new_type = DT_STRING;
                 new_data = dpnode->prop.prop_str.value;
-                if(dpnode->prop.prop_str.value) {
+                if (dpnode->prop.prop_str.value) {
                     new_len = strlen(dpnode->prop.prop_str.value);
-                }else {
+                } else {
                     new_len = 0;
                 }
             } break;
             case PROP_ENUM: {
                 new_type = DT_ENUM;
                 new_data = &(dpnode->prop.prop_enum.value);
-                new_len = DT_ENUM_LEN;
+                new_len  = DT_ENUM_LEN;
             } break;
             case PROP_BITMAP: {
                 new_type = DT_BITMAP;
                 new_data = &(dpnode->prop.prop_bitmap.value);
-                new_len = DT_BITMAP_MAX;
+                new_len  = DT_BITMAP_MAX;
             } break;
             default: {
                 PR_ERR("unsupport dp type:%d", dpnode->desc.prop_tp);
@@ -696,8 +742,8 @@ static int ble_dp_query(ble_packet_t *req, void *priv_data)
     tal_mutex_unlock(schema->mutex);
 
     if (p_node != NULL) {
-        uint16_t type = FRM_DP_STAT_REPORT_V4;
-        uint8_t *p_new_data = NULL;
+        uint16_t type         = FRM_DP_STAT_REPORT_V4;
+        uint8_t *p_new_data   = NULL;
         uint32_t new_data_len = 0;
 
         klvlist_2_data(p_node, &p_new_data, &new_data_len, NULL, TRUE, 0);

--- a/src/tuya_cloud_service/ble/ble_dp_validate.c
+++ b/src/tuya_cloud_service/ble/ble_dp_validate.c
@@ -1,0 +1,74 @@
+/**
+ * @file ble_dp_validate.c
+ * @brief BLE datapoint payload validation helpers.
+ *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#include "ble_dp_validate.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#define BLE_DP_TYPE_RAW    0
+#define BLE_DP_TYPE_BOOL   1
+#define BLE_DP_TYPE_VALUE  2
+#define BLE_DP_TYPE_STRING 3
+#define BLE_DP_TYPE_ENUM   4
+#define BLE_DP_TYPE_BITMAP 5
+
+bool ble_dp_v4_payload_valid(const uint8_t *data, uint16_t len)
+{
+    return data != NULL && len >= 5;
+}
+
+bool ble_dp_klv_length_valid(uint8_t type, uint16_t len)
+{
+    switch (type) {
+    case BLE_DP_TYPE_RAW:
+    case BLE_DP_TYPE_STRING:
+        return len <= 255;
+    case BLE_DP_TYPE_BOOL:
+        return len == 1;
+    case BLE_DP_TYPE_VALUE:
+        return len == 4;
+    case BLE_DP_TYPE_ENUM:
+    case BLE_DP_TYPE_BITMAP:
+        return len == 1 || len == 2 || len == 4;
+    default:
+        return false;
+    }
+}
+
+bool ble_dp_enum_value_valid(uint32_t value, int count, char *const *values)
+{
+    return count > 0 && values != NULL && value < (uint32_t)count && values[value] != NULL;
+}
+
+bool ble_dp_scalar_to_big_endian(const void *data, uint16_t len, uint8_t *output)
+{
+    if (data == NULL || output == NULL || (len != 1 && len != 2 && len != 4)) {
+        return false;
+    }
+
+    uint32_t value = 0;
+    if (len == 1) {
+        value = *(const uint8_t *)data;
+    } else if (len == 2) {
+        uint16_t value16;
+        memcpy(&value16, data, sizeof(value16));
+        value = value16;
+    } else {
+        memcpy(&value, data, sizeof(value));
+    }
+
+    for (uint16_t i = 0; i < len; i++) {
+        output[i] = (uint8_t)(value >> ((len - i - 1) * 8));
+    }
+    return true;
+}
+
+bool ble_dp_client_ready(bool is_activated, const void *schema)
+{
+    return is_activated && schema != NULL;
+}

--- a/src/tuya_cloud_service/ble/ble_dp_validate.h
+++ b/src/tuya_cloud_service/ble/ble_dp_validate.h
@@ -1,0 +1,20 @@
+/**
+ * @file ble_dp_validate.h
+ * @brief BLE datapoint payload validation helpers.
+ *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#ifndef __BLE_DP_VALIDATE_H__
+#define __BLE_DP_VALIDATE_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool ble_dp_v4_payload_valid(const uint8_t *data, uint16_t len);
+bool ble_dp_klv_length_valid(uint8_t type, uint16_t len);
+bool ble_dp_enum_value_valid(uint32_t value, int count, char *const *values);
+bool ble_dp_scalar_to_big_endian(const void *data, uint16_t len, uint8_t *output);
+bool ble_dp_client_ready(bool is_activated, const void *schema);
+
+#endif

--- a/src/tuya_cloud_service/ble/ble_mgr.c
+++ b/src/tuya_cloud_service/ble/ble_mgr.c
@@ -8,7 +8,7 @@
  * BLE sessions, and processing received BLE packets. It also includes
  * encryption and decryption of BLE packets for secure communication.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -26,6 +26,8 @@
 #include "tal_bluetooth.h"
 #include "crc_16.h"
 #include "uni_random.h"
+#include "ble_security_policy.h"
+#include "ble_mgr_bounds.h"
 
 /* This module is compiled whenever the chip has a BLE controller
  * (CONFIG_ENABLE_BLUETOOTH, see the CMakeLists), but the advertising interval comes
@@ -52,32 +54,32 @@
 #define BLE_ID_LEN 16
 typedef struct {
     ble_session_fn_t function;
-    void *priv_data;
+    void            *priv_data;
 } ble_session_t;
 
 typedef struct {
     ble_frame_trsmitr_t *trsmitr;
-    uint32_t raw_len;
-    uint8_t raw_buf[TUYA_BLE_AIR_FRAME_MAX];
-    uint32_t dec_len;
-    uint8_t dec_buf[TUYA_BLE_AIR_FRAME_MAX];
+    uint32_t             raw_len;
+    uint8_t              raw_buf[TUYA_BLE_AIR_FRAME_MAX];
+    uint32_t             dec_len;
+    uint8_t              dec_buf[TUYA_BLE_AIR_FRAME_MAX];
 } ble_packet_recv_t;
 
 typedef struct {
     tuya_ble_cfg_t cfg;
 
-    uint8_t id[16 + 1];
-    bool is_id_comp;
+    uint8_t            id[16 + 1];
+    bool               is_id_comp;
     ble_crypto_param_t crypto_param;
 
     TIMER_ID pair_timer; //! Illegal pairing detection
     TIMER_ID monitor_timer;
 
     uint8_t pair_rand[6];
-    bool is_paired;
-    bool *is_bound;
+    bool    is_paired;
+    bool   *is_bound;
     //! tal ble
-    TAL_BLE_ROLE_E role;
+    TAL_BLE_ROLE_E      role;
     TAL_BLE_PEER_INFO_T peer_info;
     //! adv & scan rsp
     uint8_t adv_len;
@@ -85,14 +87,14 @@ typedef struct {
     uint8_t rsp_len;
     uint8_t rsp_data[BLE_SCAN_RSP_DATA_LEN];
     //! packet receive
-    uint32_t send_sn;
-    uint32_t recv_sn;
+    uint32_t           send_sn;
+    uint32_t           recv_sn;
     ble_packet_recv_t *packet_recv;
-    ble_session_t session[BLE_SESSION_MAX];
+    ble_session_t      session[BLE_SESSION_MAX];
 } tuya_ble_mgr_t;
 
-static tuya_ble_mgr_t *s_ble_mgr = NULL;
-static bool s_ble_debug = false;
+static tuya_ble_mgr_t *s_ble_mgr   = NULL;
+static bool            s_ble_debug = false;
 
 /**
  * @brief Prints the raw data in hexadecimal format.
@@ -177,12 +179,12 @@ static int ble_adv_set(tuya_ble_mgr_t *ble)
     ble->rsp_data[ble->rsp_len++] = TUYA_BLE_DEVICE_COMMUNICATION_ABILITY;
 
     uint8_t *flag = (uint8_t *)&ble->rsp_data[ble->rsp_len++];
-    *flag = 0x00; // bond flag bit7 (8)
+    *flag         = 0x00; // bond flag bit7 (8)
     if (ble->is_id_comp) {
         *flag |= ADV_FLAG_UUID_COMP;
     }
     /* adv&rsp data */
-    uint8_t *key_in = (uint8_t *)&ble->adv_data[ble->adv_len];
+    uint8_t *key_in               = (uint8_t *)&ble->adv_data[ble->adv_len];
     ble->adv_data[ble->adv_len++] = (frame_ctrl >> 8) & 0xff;
     ble->adv_data[ble->adv_len++] = (uint8_t)frame_ctrl & 0xff;
     ble->adv_data[ble->adv_len++] = 0x00;       //! id type 00-pid 01-product key
@@ -217,14 +219,18 @@ static int ble_adv_set(tuya_ble_mgr_t *ble)
 
 static uint32_t ble_packet_trsmitr(ble_packet_recv_t *packet_recv, uint8_t *buf, uint32_t len)
 {
-    static uint32_t pack_no = 0;
-    uint32_t subpkg_len = 0;
+    uint32_t previous_received = packet_recv->trsmitr->pkg_trsmitr_cnt;
+    uint32_t subpkg_len        = 0;
 
     int rt = ble_frame_trsmitr_recv_pkg_decode(packet_recv->trsmitr, buf, len);
     if (OPRT_OK != rt && OPRT_SVC_BT_API_TRSMITR_CONTINUE != rt) { // decode error
         packet_recv->raw_len = 0;
         memset(packet_recv->raw_buf, 0, sizeof(packet_recv->raw_buf));
+        ble_frame_trsmitr_reset(packet_recv->trsmitr);
         return rt;
+    }
+    if (previous_received != 0 && packet_recv->trsmitr->pkg_trsmitr_cnt == previous_received) {
+        return OPRT_SVC_BT_API_TRSMITR_CONTINUE;
     }
     // For the first packet of a multi-packet transmission, or in the case of a
     // single packet, it is necessary to clear the cache.
@@ -232,18 +238,18 @@ static uint32_t ble_packet_trsmitr(ble_packet_recv_t *packet_recv, uint8_t *buf,
         (BLE_FRAME_PKG_END == packet_recv->trsmitr->pkg_desc && 0 == packet_recv->trsmitr->subpkg_num)) {
         packet_recv->raw_len = 0;
         memset(packet_recv->raw_buf, 0, sizeof(packet_recv->raw_buf));
-        pack_no = 0;
     }
-    pack_no++;
     subpkg_len = ble_frame_subpacket_len_get(packet_recv->trsmitr);
-    PR_DEBUG("ble recv sub_pkg desc:%d, no:%d, pack_len:%d, total_len:%d", packet_recv->trsmitr->pkg_desc, pack_no,
-             subpkg_len, packet_recv->raw_len + subpkg_len);
+    PR_DEBUG("ble recv sub_pkg desc:%d, no:%d, pack_len:%d, total_len:%d", packet_recv->trsmitr->pkg_desc,
+             packet_recv->trsmitr->subpkg_num, subpkg_len, packet_recv->raw_len + subpkg_len);
 
     if ((packet_recv->raw_len + subpkg_len) <= TUYA_BLE_AIR_FRAME_MAX) {
         memcpy(packet_recv->raw_buf + packet_recv->raw_len, ble_frame_subpacket_get(packet_recv->trsmitr), subpkg_len);
     } else {
-        rt = OPRT_INVALID_PARM;
         PR_ERR("ble unpack overflow, desc:%d, pack_len:%d", packet_recv->trsmitr->pkg_desc, subpkg_len);
+        packet_recv->raw_len = 0;
+        ble_frame_trsmitr_reset(packet_recv->trsmitr);
+        return OPRT_INVALID_PARM;
     }
 
     packet_recv->raw_len += subpkg_len;
@@ -275,7 +281,7 @@ static uint32_t ble_packet_trsmitr(ble_packet_recv_t *packet_recv, uint8_t *buf,
 
 static int ble_packet_recv(tuya_ble_mgr_t *ble, uint8_t *buf, uint16_t len, ble_packet_t *packet)
 {
-    int rt = OPRT_OK;
+    int                rt          = OPRT_OK;
     ble_packet_recv_t *packet_recv = s_ble_mgr->packet_recv;
 
     rt = ble_packet_trsmitr(packet_recv, buf, len);
@@ -295,6 +301,10 @@ static int ble_packet_recv(tuya_ble_mgr_t *ble, uint8_t *buf, uint16_t len, ble_
         PR_ERR("ble trsmitr version not compatibility! %d", packet_recv->trsmitr->version);
         return OPRT_INVALID_PARM;
     }
+    if (*ble->is_bound && packet_recv->raw_buf[0] == ENCRYPTION_MODE_NONE) {
+        PR_ERR("bound device rejects plaintext BLE packet");
+        return OPRT_INVALID_PARM;
+    }
     tuya_ble_raw_print("ble raw packet", 8, packet_recv->raw_buf, packet_recv->raw_len);
     memset(packet_recv->dec_buf, 0, TUYA_BLE_AIR_FRAME_MAX);
     rt = tuya_ble_decryption(&ble->crypto_param, packet_recv->raw_buf, packet_recv->raw_len, &packet_recv->dec_len,
@@ -303,51 +313,57 @@ static int ble_packet_recv(tuya_ble_mgr_t *ble, uint8_t *buf, uint16_t len, ble_
         PR_ERR("ble packet decrypt err:%d", rt);
         return OPRT_INVALID_PARM;
     }
+    if (packet_recv->dec_len < BLE_PACKET_MIN_LEN) {
+        PR_ERR("ble decrypted packet too short:%d", packet_recv->dec_len);
+        return OPRT_INVALID_PARM;
+    }
     tuya_ble_raw_print("ble dec packet", 8, packet_recv->dec_buf, packet_recv->dec_len);
     uint16_t data_len = 0;
-    data_len = packet_recv->dec_buf[BLE_PACKET_DLEN_IND] << 8;
+    data_len          = packet_recv->dec_buf[BLE_PACKET_DLEN_IND] << 8;
     data_len += packet_recv->dec_buf[BLE_PACKET_DLEN_IND + 1];
-    if (data_len + BLE_PACKET_MIN_LEN > TUYA_BLE_AIR_FRAME_MAX) {
+    if ((uint32_t)data_len + BLE_PACKET_MIN_LEN > packet_recv->dec_len ||
+        (uint32_t)data_len + BLE_PACKET_MIN_LEN > TUYA_BLE_AIR_FRAME_MAX) {
         PR_ERR("ble packet len err:%d", (data_len + BLE_PACKET_MIN_LEN));
         return OPRT_INVALID_PARM;
     }
     // crc check
     uint16_t our_crc = 0;
-    our_crc = packet_recv->dec_buf[BLE_PACKET_CRC16_IND + data_len] << 8;
+    our_crc          = packet_recv->dec_buf[BLE_PACKET_CRC16_IND + data_len] << 8;
     our_crc += packet_recv->dec_buf[BLE_PACKET_CRC16_IND + data_len + 1];
     uint16_t his_crc = get_crc_16(packet_recv->dec_buf, data_len + BLE_PACKET_DATA_IND);
     if (our_crc != his_crc) {
         PR_ERR("ble packet crc err:0x%04x, 0x%04x", our_crc, his_crc);
         return OPRT_INVALID_PARM;
     }
+    packet->type = packet_recv->dec_buf[BLE_PACKET_CMD_IND] << 8;
+    packet->type += packet_recv->dec_buf[BLE_PACKET_CMD_IND + 1];
+    packet->encrypt_mode = packet_recv->raw_buf[0];
+    if (!ble_security_packet_allowed(*ble->is_bound, ble->is_paired, packet->type, packet->encrypt_mode)) {
+        PR_ERR("unauthorized BLE command:0x%04x", packet->type);
+        return OPRT_INVALID_PARM;
+    }
+
     // sn check
-    uint32_t recv_sn = 0;
-    recv_sn = packet_recv->dec_buf[BLE_PACKET_SN_IND] << 24;
-    recv_sn += packet_recv->dec_buf[BLE_PACKET_SN_IND + 1] << 16;
-    recv_sn += packet_recv->dec_buf[BLE_PACKET_SN_IND + 2] << 8;
-    recv_sn += packet_recv->dec_buf[BLE_PACKET_SN_IND + 3];
+    uint32_t recv_sn = ble_mgr_u32_from_big_endian(&packet_recv->dec_buf[BLE_PACKET_SN_IND]);
     PR_NOTICE("ble sn:%d recv sn %d", recv_sn, ble->recv_sn);
     if (recv_sn <= ble->recv_sn) {
         PR_ERR("ble recv sn err");
         tal_ble_disconnect(ble->peer_info);
         return OPRT_INVALID_PARM;
-    } else {
-        ble->recv_sn = recv_sn;
     }
-    packet->type = packet_recv->dec_buf[BLE_PACKET_CMD_IND] << 8;
-    packet->type += packet_recv->dec_buf[BLE_PACKET_CMD_IND + 1];
-    packet->len = data_len;
-    packet->sn = recv_sn;
+    packet->len  = data_len;
+    packet->sn   = recv_sn;
     packet->data = NULL;
-    packet->encrypt_mode = packet_recv->raw_buf[0];
     if (0 != packet->len) {
-        packet->data = (uint8_t *)tal_malloc(packet->len);
+        packet->data = (uint8_t *)tal_malloc(packet->len + 1);
         if (packet->data == NULL) {
             PR_DEBUG("ble packet malloc err");
             return OPRT_MALLOC_FAILED;
         }
         memcpy(packet->data, &packet_recv->dec_buf[BLE_PACKET_DATA_IND], packet->len);
+        packet->data[packet->len] = '\0';
     }
+    ble->recv_sn = recv_sn;
 
     return OPRT_OK;
 }
@@ -363,9 +379,9 @@ static void ble_adv_update(tuya_ble_mgr_t *ble)
     TAL_BLE_DATA_T rsp_data;
 
     adv_data.p_data = ble->adv_data;
-    adv_data.len = ble->adv_len;
+    adv_data.len    = ble->adv_len;
     rsp_data.p_data = ble->rsp_data;
-    rsp_data.len = ble->rsp_len;
+    rsp_data.len    = ble->rsp_len;
 
     // Only update the advertising content when Bluetooth is connected
     if (ble->is_paired) {
@@ -407,8 +423,8 @@ static void ble_pair_timeout_cb(TIMER_ID timer_id, void *arg)
 /* gateway auto check callback*/
 static void ble_mointor_timer_cb(TIMER_ID timer_id, void *arg)
 {
-    static bool s_iot_conn_stat = false;
-    tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)arg;
+    static bool     s_iot_conn_stat = false;
+    tuya_ble_mgr_t *ble             = (tuya_ble_mgr_t *)arg;
 
     if (tuya_iot_is_connected()) {
         if (s_iot_conn_stat) {
@@ -472,7 +488,7 @@ int tuya_ble_session_add(ble_seesion_type_t type, ble_session_fn_t fn, void *pri
     tuya_ble_mgr_t *ble = s_ble_mgr;
 
     if (type < BLE_SESSION_MAX) {
-        ble->session[type].function = fn;
+        ble->session[type].function  = fn;
         ble->session[type].priv_data = priv_data;
         return OPRT_OK;
     }
@@ -496,7 +512,7 @@ int tuya_ble_session_del(ble_seesion_type_t type)
     tuya_ble_mgr_t *ble = s_ble_mgr;
 
     if (type < BLE_SESSION_MAX) {
-        ble->session[type].function = NULL;
+        ble->session[type].function  = NULL;
         ble->session[type].priv_data = NULL;
         return OPRT_OK;
     }
@@ -507,15 +523,20 @@ int tuya_ble_session_del(ble_seesion_type_t type)
 static int ble_packet_encode(tuya_ble_mgr_t *ble, ble_packet_t *packet, uint8_t **outbuf, uint32_t *outlen)
 {
     uint8_t *ble_frame = NULL;
-    uint8_t *enc_buf = NULL;
+    uint8_t *enc_buf   = NULL;
+
+    if (ble == NULL || packet == NULL || outbuf == NULL || outlen == NULL ||
+        (packet->len != 0 && packet->data == NULL) || packet->len > TUYA_BLE_AIR_FRAME_MAX - BLE_PACKET_MIN_LEN) {
+        return OPRT_INVALID_PARM;
+    }
 
     ble_frame = tal_malloc(TUYA_BLE_AIR_FRAME_MAX);
-    enc_buf = tal_malloc(TUYA_BLE_AIR_FRAME_MAX);
+    enc_buf   = tal_malloc(TUYA_BLE_AIR_FRAME_MAX);
     if (NULL == enc_buf || NULL == ble_frame) {
         PR_ERR("ble enc_buf malloc err");
         goto __exit;
     }
-    uint32_t send_sn = ble->send_sn++;
+    uint32_t send_sn   = ble->send_sn++;
     uint32_t frame_len = 0;
     //! SN offset = 0
     ble_frame[frame_len++] = send_sn >> 24;
@@ -539,11 +560,11 @@ static int ble_packet_encode(tuya_ble_mgr_t *ble, ble_packet_t *packet, uint8_t 
     }
     //! CRC16 offset(12) + app_data->len
     frame_len += packet->len;
-    uint16_t crc16 = get_crc_16(ble_frame, frame_len);
+    uint16_t crc16         = get_crc_16(ble_frame, frame_len);
     ble_frame[frame_len++] = crc16 >> 8;
     ble_frame[frame_len++] = crc16;
     //! flag + iv = 17
-    enc_buf[0] = packet->encrypt_mode;
+    enc_buf[0]           = packet->encrypt_mode;
     uint16_t padding_len = 17;
     if (frame_len % 16) {
         padding_len += 16 - frame_len % 16;
@@ -553,7 +574,7 @@ static int ble_packet_encode(tuya_ble_mgr_t *ble, ble_packet_t *packet, uint8_t 
         goto __exit;
     }
     uint32_t enc_len = 0;
-    uint8_t iv[16];
+    uint8_t  iv[16];
     uni_random_bytes(iv, 16);
     memcpy(&enc_buf[1], iv, 16);
     if (tuya_ble_encryption(&ble->crypto_param, packet->encrypt_mode, iv, ble_frame, frame_len, &enc_len,
@@ -580,15 +601,15 @@ __exit:
 
 static int ble_packet_resp(tuya_ble_mgr_t *ble, ble_packet_t *resp)
 {
-    int rt = OPRT_OK;
-    uint8_t *pbuf = NULL;
+    int                  rt      = OPRT_OK;
+    uint8_t             *pbuf    = NULL;
     ble_frame_trsmitr_t *trsmitr = NULL;
-    uint8_t *outbuf = NULL;
-    uint32_t outlen;
+    uint8_t             *outbuf  = NULL;
+    uint32_t             outlen;
 
     TUYA_CALL_ERR_GOTO(ble_packet_encode(ble, resp, &outbuf, &outlen), __exit);
     uint16_t buf_len = ble_frame_packet_len_get();
-    rt = OPRT_MALLOC_FAILED;
+    rt               = OPRT_MALLOC_FAILED;
     TUYA_CHECK_NULL_GOTO(pbuf = (uint8_t *)tal_malloc(buf_len), __exit);
     memset(pbuf, 0, buf_len);
     TUYA_CHECK_NULL_GOTO(trsmitr = ble_frame_trsmitr_create(), __exit);
@@ -604,7 +625,7 @@ static int ble_packet_resp(tuya_ble_mgr_t *ble, ble_packet_t *resp)
         TAL_BLE_DATA_T ble_data;
 
         ble_data.p_data = pbuf;
-        ble_data.len = send_len;
+        ble_data.len    = send_len;
 
         TUYA_CALL_ERR_GOTO(tal_ble_server_common_send(&ble_data), __exit);
         tal_system_sleep(20);
@@ -679,10 +700,10 @@ int tuya_ble_send(uint16_t type, uint32_t ack_sn, uint8_t *data, uint32_t len)
 {
     ble_packet_t packet;
 
-    packet.type = type;
-    packet.data = data;
-    packet.len = len;
-    packet.sn = ack_sn;
+    packet.type         = type;
+    packet.data         = data;
+    packet.len          = len;
+    packet.sn           = ack_sn;
     packet.encrypt_mode = 0;
 
     return tuya_ble_send_packet(&packet);
@@ -690,19 +711,24 @@ int tuya_ble_send(uint16_t type, uint32_t ack_sn, uint8_t *data, uint32_t len)
 
 static int ble_unbind_req(ble_packet_t *req, void *priv_data)
 {
-    uint8_t result_code = 1;
-    tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)priv_data;
+    uint8_t            result_code = 1;
+    tuya_ble_mgr_t    *ble         = (tuya_ble_mgr_t *)priv_data;
+    tuya_iot_client_t *client      = tuya_iot_client_get();
+    if (req == NULL || ble == NULL || client == NULL || ble->is_bound == NULL || !ble->is_paired || !*ble->is_bound ||
+        req->encrypt_mode == ENCRYPTION_MODE_NONE) {
+        return OPRT_INVALID_PARM;
+    }
     ble_packet_t resp;
 
-    resp.sn = req->sn;
-    resp.type = req->type;
-    resp.len = 1;
-    resp.data = &result_code;
+    resp.sn           = req->sn;
+    resp.type         = req->type;
+    resp.len          = 1;
+    resp.data         = &result_code;
     resp.encrypt_mode = req->encrypt_mode;
 
     ble_packet_resp(ble, &resp);
-    tuya_iot_reset(tuya_iot_client_get());
-    tuya_iot_client_get()->is_activated = false;
+    tuya_iot_reset(client);
+    client->is_activated = false;
     tal_ble_disconnect(ble->peer_info);
 
     return OPRT_OK;
@@ -710,9 +736,13 @@ static int ble_unbind_req(ble_packet_t *req, void *priv_data)
 
 static int ble_pair_req(ble_packet_t *req, void *priv_data)
 {
-    int rt;
-    uint8_t result;
+    int             rt;
+    uint8_t         result;
     tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)priv_data;
+
+    if (req == NULL || req->data == NULL || req->len < BLE_ID_LEN || ble == NULL) {
+        return OPRT_INVALID_PARM;
+    }
 
     if (0 == memcmp(req->data, ble->crypto_param.uuid, BLE_ID_LEN)) {
         tal_sw_timer_stop(ble->pair_timer);
@@ -729,10 +759,10 @@ static int ble_pair_req(ble_packet_t *req, void *priv_data)
     }
     ble_packet_t resp;
 
-    resp.sn = req->sn;
-    resp.type = req->type;
-    resp.len = 1;
-    resp.data = &result;
+    resp.sn           = req->sn;
+    resp.type         = req->type;
+    resp.len          = 1;
+    resp.data         = &result;
     resp.encrypt_mode = req->encrypt_mode;
 
     TUYA_CALL_ERR_GOTO(ble_packet_resp(ble, &resp), __exit);
@@ -754,6 +784,9 @@ __exit:
 
 static uint8_t ble_dev_info_make(tuya_ble_mgr_t *ble, uint8_t *pbuf, uint8_t buflen)
 {
+    if (!ble_mgr_dev_info_buffer_valid(ble, pbuf, buflen)) {
+        return 0;
+    }
     uint8_t payload_len = 0;
 
     //! protocol version
@@ -814,25 +847,22 @@ static uint8_t ble_dev_info_make(tuya_ble_mgr_t *ble, uint8_t *pbuf, uint8_t buf
 
 static int ble_dev_info_req(ble_packet_t *req, void *priv_data)
 {
-    int rt;
-    uint8_t *pbuf = NULL;
-    uint8_t buf_len = 128;
-    tuya_ble_mgr_t *ble = (tuya_ble_mgr_t *)priv_data;
+    int             rt;
+    uint8_t        *pbuf    = NULL;
+    uint8_t         buf_len = 128;
+    tuya_ble_mgr_t *ble     = (tuya_ble_mgr_t *)priv_data;
+
+    if (req == NULL || ble == NULL || ble->packet_recv == NULL || ble->packet_recv->trsmitr == NULL) {
+        return OPRT_INVALID_PARM;
+    }
 
     // Gets the Bluetooth subcontract length from the protocol
-    uint16_t pkg_len = (req->data[0] << 8 & 0xff00) + (req->data[1] & 0xff);
-    ble_frame_packet_len_set(pkg_len);
+    uint16_t pkg_len = 0;
+    TUYA_CALL_ERR_RETURN(ble_mgr_packet_length_parse(req->data, req->len, &pkg_len));
     ble_frame_trsmitr_t *trsmitr = ble->packet_recv->trsmitr;
-    if (trsmitr->subpkg) {
-        tal_free(trsmitr->subpkg);
-        trsmitr->subpkg = NULL;
-    }
-    trsmitr->subpkg = (uint8_t *)tal_malloc(pkg_len);
-    if (trsmitr->subpkg == NULL) {
-        PR_ERR("malloc err:%d", pkg_len);
-        return OPRT_MALLOC_FAILED;
-    }
-    memset(trsmitr->subpkg, 0, pkg_len);
+    TUYA_CALL_ERR_RETURN(ble_mgr_subpkg_resize(&trsmitr->subpkg, &trsmitr->subpkg_capacity, pkg_len));
+    ble_frame_trsmitr_reset(trsmitr);
+    ble_frame_packet_len_set(pkg_len);
     PR_NOTICE("ble dev info: state:%d, pkg_len:%d", *ble->is_bound, ble_frame_packet_len_get());
 
     pbuf = (uint8_t *)tal_malloc(buf_len);
@@ -842,13 +872,17 @@ static int ble_dev_info_req(ble_packet_t *req, void *priv_data)
     }
     memset(pbuf, 0, buf_len);
     buf_len = ble_dev_info_make(ble, pbuf, buf_len);
+    if (buf_len == 0) {
+        rt = OPRT_INVALID_PARM;
+        goto __exit;
+    }
     // tuya_ble_raw_print("ble dev info:", 8, pbuf, buf_len);
 
     ble_packet_t resp;
-    resp.sn = req->sn;
-    resp.type = req->type;
-    resp.len = buf_len;
-    resp.data = pbuf;
+    resp.sn           = req->sn;
+    resp.type         = req->type;
+    resp.len          = buf_len;
+    resp.data         = pbuf;
     resp.encrypt_mode = req->encrypt_mode;
 
     TUYA_CALL_ERR_GOTO(ble_packet_resp(ble, &resp), __exit);
@@ -859,6 +893,22 @@ __exit:
     }
 
     return rt;
+}
+
+static void ble_packet_length_restore(tuya_ble_mgr_t *ble)
+{
+    if (ble == NULL || ble->packet_recv == NULL || ble->packet_recv->trsmitr == NULL) {
+        return;
+    }
+
+    ble_frame_trsmitr_t *trsmitr = ble->packet_recv->trsmitr;
+    ble_mgr_subpkg_resize(&trsmitr->subpkg, &trsmitr->subpkg_capacity, TUYA_BLE_AIR_FRAME_MAX);
+    ble_frame_trsmitr_reset(trsmitr);
+    ble_frame_packet_len_set(trsmitr->subpkg_capacity);
+    ble->packet_recv->raw_len = 0;
+    ble->packet_recv->dec_len = 0;
+    memset(ble->packet_recv->raw_buf, 0, sizeof(ble->packet_recv->raw_buf));
+    memset(ble->packet_recv->dec_buf, 0, sizeof(ble->packet_recv->dec_buf));
 }
 
 /**
@@ -897,7 +947,7 @@ void ble_session_system_process(ble_packet_t *packet, void *priv_data)
 }
 
 // ble event params malloc&copy
-static TAL_BLE_EVT_PARAMS_T * ble_event_msg_copy(TAL_BLE_EVT_PARAMS_T *evt)
+static TAL_BLE_EVT_PARAMS_T *ble_event_msg_copy(TAL_BLE_EVT_PARAMS_T *evt)
 {
     TAL_BLE_EVT_PARAMS_T *msg = NULL;
 
@@ -908,14 +958,13 @@ static TAL_BLE_EVT_PARAMS_T * ble_event_msg_copy(TAL_BLE_EVT_PARAMS_T *evt)
     memcpy(msg, evt, sizeof(TAL_BLE_EVT_PARAMS_T));
 
     if (TAL_BLE_EVT_WRITE_REQ == evt->type && evt->ble_event.write_report.report.len > 0) {
-        msg->ble_event.write_report.report.p_data =
-            tal_malloc(evt->ble_event.write_report.report.len);
+        msg->ble_event.write_report.report.p_data = tal_malloc(evt->ble_event.write_report.report.len);
         if (NULL == msg->ble_event.write_report.report.p_data) {
             tal_free(msg);
             return NULL;
         }
         memcpy(msg->ble_event.write_report.report.p_data, evt->ble_event.write_report.report.p_data,
-                evt->ble_event.write_report.report.len);
+               evt->ble_event.write_report.report.len);
     }
 
     return msg;
@@ -960,6 +1009,8 @@ static void tal_ble_event_callback(void *data)
             memcpy(&ble->peer_info, &msg->ble_event.connect.peer, sizeof(TAL_BLE_PEER_INFO_T));
             ble->recv_sn = 0;
             ble->send_sn = 1;
+            ble_packet_length_restore(ble);
+            ble_channel_reset();
             tal_sw_timer_start(ble->pair_timer, BLE_CONN_MONITOR_TIME, TAL_TIMER_ONCE);
             PR_NOTICE("Ble Connected");
         } else {
@@ -972,6 +1023,8 @@ static void tal_ble_event_callback(void *data)
         memset(ble->pair_rand, 0x00, sizeof(ble->pair_rand));
         tal_sw_timer_stop(ble->pair_timer);
         ble->is_paired = false;
+        ble_packet_length_restore(ble);
+        ble_channel_reset();
         if (!tuya_iot_is_connected()) {
             ble_adv_update(ble);
         }
@@ -979,8 +1032,8 @@ static void tal_ble_event_callback(void *data)
     } break;
 
     case TAL_BLE_EVT_WRITE_REQ: {
-        int ret = OPRT_OK;
-        ble_packet_t packet;
+        int             ret = OPRT_OK;
+        ble_packet_t    packet;
         TAL_BLE_DATA_T *report;
 
         if (msg->ble_event.write_report.peer.char_handle[0] ==
@@ -1039,6 +1092,7 @@ int tuya_ble_deinit(void)
         return OPRT_OK;
     }
     PR_NOTICE("ble deinit...");
+    ble_channel_reset();
     if (ble->pair_timer) {
         tal_sw_timer_delete(ble->pair_timer);
     }
@@ -1100,7 +1154,7 @@ int tuya_ble_init(tuya_ble_cfg_t *cfg)
         return OPRT_OK;
     }
     tuya_ble_mgr_t *ble = NULL;
-    ble = tal_malloc(sizeof(tuya_ble_mgr_t));
+    ble                 = tal_malloc(sizeof(tuya_ble_mgr_t));
     if (NULL == ble) {
         return OPRT_MALLOC_FAILED;
     }
@@ -1125,9 +1179,9 @@ int tuya_ble_init(tuya_ble_cfg_t *cfg)
     } else {
         memcpy(ble->id, ble->cfg.client->config.uuid, 16);
     }
-    ble->crypto_param.uuid = (uint8_t *)ble->id;
-    ble->crypto_param.auth_key = (uint8_t *)ble->cfg.client->config.authkey;
-    ble->crypto_param.sec_key = (uint8_t *)ble->cfg.client->activate.seckey;
+    ble->crypto_param.uuid      = (uint8_t *)ble->id;
+    ble->crypto_param.auth_key  = (uint8_t *)ble->cfg.client->config.authkey;
+    ble->crypto_param.sec_key   = (uint8_t *)ble->cfg.client->activate.seckey;
     ble->crypto_param.login_key = (uint8_t *)ble->cfg.client->activate.localkey;
     ble->crypto_param.pair_rand = (uint8_t *)ble->pair_rand;
     TUYA_CALL_ERR_GOTO(tal_sw_timer_create(ble_pair_timeout_cb, ble, &ble->pair_timer), __exit);

--- a/src/tuya_cloud_service/ble/ble_mgr_bounds.c
+++ b/src/tuya_cloud_service/ble/ble_mgr_bounds.c
@@ -1,0 +1,57 @@
+/**
+ * @file ble_mgr_bounds.c
+ * @brief Bounds and allocation helpers for BLE manager negotiation.
+ *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#include "ble_mgr_bounds.h"
+
+#include "ble_protocol.h"
+#include "tal_api.h"
+
+int ble_mgr_packet_length_parse(const uint8_t *data, uint16_t len, uint16_t *packet_len)
+{
+    if (data == NULL || len < 2 || packet_len == NULL) {
+        return OPRT_INVALID_PARM;
+    }
+
+    uint16_t candidate = ((uint16_t)data[0] << 8) | data[1];
+    if (candidate < BLE_MGR_PACKET_LEN_MIN || candidate > TUYA_BLE_AIR_FRAME_MAX) {
+        return OPRT_INVALID_PARM;
+    }
+
+    *packet_len = candidate;
+    return OPRT_OK;
+}
+
+int ble_mgr_subpkg_resize(uint8_t **buffer, uint32_t *capacity, uint16_t new_capacity)
+{
+    if (buffer == NULL || *buffer == NULL || capacity == NULL || new_capacity < BLE_MGR_PACKET_LEN_MIN ||
+        new_capacity > TUYA_BLE_AIR_FRAME_MAX) {
+        return OPRT_INVALID_PARM;
+    }
+    if (*capacity == new_capacity) {
+        return OPRT_OK;
+    }
+
+    uint8_t *replacement = tal_malloc(new_capacity);
+    if (replacement == NULL) {
+        return OPRT_MALLOC_FAILED;
+    }
+    memset(replacement, 0, new_capacity);
+    tal_free(*buffer);
+    *buffer   = replacement;
+    *capacity = new_capacity;
+    return OPRT_OK;
+}
+
+bool ble_mgr_dev_info_buffer_valid(const void *manager, const uint8_t *buffer, uint32_t capacity)
+{
+    return manager != NULL && buffer != NULL && capacity >= BLE_MGR_DEV_INFO_LEN;
+}
+
+uint32_t ble_mgr_u32_from_big_endian(const uint8_t data[4])
+{
+    return ((uint32_t)data[0] << 24) | ((uint32_t)data[1] << 16) | ((uint32_t)data[2] << 8) | (uint32_t)data[3];
+}

--- a/src/tuya_cloud_service/ble/ble_mgr_bounds.h
+++ b/src/tuya_cloud_service/ble/ble_mgr_bounds.h
@@ -1,0 +1,22 @@
+/**
+ * @file ble_mgr_bounds.h
+ * @brief Bounds and allocation helpers for BLE manager negotiation.
+ *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#ifndef __BLE_MGR_BOUNDS_H__
+#define __BLE_MGR_BOUNDS_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define BLE_MGR_PACKET_LEN_MIN 10U
+#define BLE_MGR_DEV_INFO_LEN   121U
+
+int      ble_mgr_packet_length_parse(const uint8_t *data, uint16_t len, uint16_t *packet_len);
+int      ble_mgr_subpkg_resize(uint8_t **buffer, uint32_t *capacity, uint16_t new_capacity);
+bool     ble_mgr_dev_info_buffer_valid(const void *manager, const uint8_t *buffer, uint32_t capacity);
+uint32_t ble_mgr_u32_from_big_endian(const uint8_t data[4]);
+
+#endif

--- a/src/tuya_cloud_service/ble/ble_netcfg.c
+++ b/src/tuya_cloud_service/ble/ble_netcfg.c
@@ -10,7 +10,7 @@
  * devices over BLE, ensuring a seamless setup process for connecting Tuya smart
  * devices to the network.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -22,8 +22,8 @@
 #include "ble_channel.h"
 
 typedef struct {
-    netcfg_args_t netcfg_args;
-    netcfg_info_t netcfg_info;
+    netcfg_args_t      netcfg_args;
+    netcfg_info_t      netcfg_info;
     netcfg_finish_cb_t netcfg_finish_cb;
 } ble_netcfg_t;
 
@@ -33,17 +33,24 @@ extern int tuya_ble_adv_update(void);
 
 static void __handle_net_cfg(void *data, void *user_data)
 {
-    uint8_t result = 0;
-    uint8_t resp[5];
+    (void)user_data;
+    uint8_t result  = 0;
+    uint8_t resp[5] = {0};
+    cJSON  *json    = NULL;
 
-    cJSON *json = cJSON_Parse(data);
+    if (data == NULL) {
+        result = (uint8_t)OPRT_CJSON_PARSE_ERR;
+        goto __exit;
+    }
+
+    json = cJSON_Parse(data);
     if (NULL == json) {
         PR_ERR(" json parse error.");
         result = (uint8_t)OPRT_CJSON_PARSE_ERR;
         goto __exit;
     }
 
-    cJSON *ssid_item = cJSON_GetObjectItem(json, "ssid");
+    cJSON *ssid_item  = cJSON_GetObjectItem(json, "ssid");
     cJSON *token_item = cJSON_GetObjectItem(json, "token");
     if (!cJSON_IsString(ssid_item) || !cJSON_IsString(token_item)) {
         PR_ERR(" json get error.");
@@ -51,9 +58,9 @@ static void __handle_net_cfg(void *data, void *user_data)
         goto __exit;
     }
 
-    char *ssid = ssid_item->valuestring;
-    char *token = token_item->valuestring;
-    char *passwd = NULL;
+    char  *ssid        = ssid_item->valuestring;
+    char  *token       = token_item->valuestring;
+    char  *passwd      = NULL;
     cJSON *passwd_item = cJSON_GetObjectItem(json, "pwd");
     if (passwd_item != NULL && cJSON_IsString(passwd_item)) {
         passwd = passwd_item->valuestring;
@@ -77,7 +84,7 @@ static void __handle_net_cfg(void *data, void *user_data)
     }
     memcpy(g_bt_netcfg_handle.netcfg_info.ssid, ssid, s_len);
     g_bt_netcfg_handle.netcfg_info.ssid[s_len] = '\0';
-    g_bt_netcfg_handle.netcfg_info.s_len = (uint8_t)s_len;
+    g_bt_netcfg_handle.netcfg_info.s_len       = (uint8_t)s_len;
 
     // Copy password
     size_t p_len = strnlen(passwd, WIFI_PASSWD_LEN + 1);
@@ -88,7 +95,7 @@ static void __handle_net_cfg(void *data, void *user_data)
     }
     memcpy(g_bt_netcfg_handle.netcfg_info.passwd, passwd, p_len);
     g_bt_netcfg_handle.netcfg_info.passwd[p_len] = '\0';
-    g_bt_netcfg_handle.netcfg_info.p_len = (uint8_t)p_len;
+    g_bt_netcfg_handle.netcfg_info.p_len         = (uint8_t)p_len;
 
     // Copy token
     size_t t_len = strnlen(token, WL_TOKEN_LEN + 1);
@@ -99,7 +106,7 @@ static void __handle_net_cfg(void *data, void *user_data)
     }
     memcpy(g_bt_netcfg_handle.netcfg_info.token, token, t_len);
     g_bt_netcfg_handle.netcfg_info.token[t_len] = '\0';
-    g_bt_netcfg_handle.netcfg_info.t_len = (uint8_t)t_len;
+    g_bt_netcfg_handle.netcfg_info.t_len        = (uint8_t)t_len;
     g_bt_netcfg_handle.netcfg_finish_cb(NETCFG_TUYA_BLE, &g_bt_netcfg_handle.netcfg_info);
 
     cJSON *reg = cJSON_GetObjectItem(json, "reg");
@@ -111,6 +118,7 @@ __exit:
     if (json) {
         cJSON_Delete(json);
     }
+    resp[0] = 0x00;
     resp[1] = 0x00; // for blt timer task, set as not subpacket, not response
     resp[2] = 0x00;
     resp[3] = FRM_DATA_TRANS_SUBCMD_BT_NETCFG;

--- a/src/tuya_cloud_service/ble/ble_security_policy.c
+++ b/src/tuya_cloud_service/ble/ble_security_policy.c
@@ -1,0 +1,22 @@
+/**
+ * @file ble_security_policy.c
+ * @brief Central authorization policy for inbound BLE commands.
+ *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#include "ble_security_policy.h"
+
+#include "ble_cryption.h"
+#include "ble_protocol.h"
+
+bool ble_security_packet_allowed(bool is_bound, bool is_paired, uint16_t type, uint8_t encryption_mode)
+{
+    if (is_bound && encryption_mode == ENCRYPTION_MODE_NONE) {
+        return false;
+    }
+    if (!is_paired && type != FRM_QRY_DEV_INFO_REQ && type != FRM_PAIR_REQ) {
+        return false;
+    }
+    return true;
+}

--- a/src/tuya_cloud_service/ble/ble_security_policy.h
+++ b/src/tuya_cloud_service/ble/ble_security_policy.h
@@ -1,0 +1,16 @@
+/**
+ * @file ble_security_policy.h
+ * @brief Central authorization policy for inbound BLE commands.
+ *
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#ifndef __BLE_SECURITY_POLICY_H__
+#define __BLE_SECURITY_POLICY_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool ble_security_packet_allowed(bool is_bound, bool is_paired, uint16_t type, uint8_t encryption_mode);
+
+#endif

--- a/src/tuya_cloud_service/ble/ble_trsmitr.c
+++ b/src/tuya_cloud_service/ble/ble_trsmitr.c
@@ -5,7 +5,7 @@
  * including encoding and decoding BLE packets for communication between
  * devices.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -13,6 +13,8 @@
 #include "ble_trsmitr.h"
 #include "ble_mgr.h"
 #include "ble_dp.h"
+
+#include <stdbool.h>
 
 #define __MUTLI_TSF_PROTOCOL_GLOBALS
 
@@ -23,8 +25,43 @@
 /***********************************************************
 *************************variable define********************
 ***********************************************************/
-static ble_frame_seq_t s_ble_frame_seq = 0;
-static uint16_t s_ble_frame_packet_len = 1024;
+static ble_frame_seq_t s_ble_frame_seq        = 0;
+static uint16_t        s_ble_frame_packet_len = 1024;
+
+static int ble_frame_varint_decode(const uint8_t *data, uint16_t data_len, uint16_t *offset, uint32_t *value)
+{
+    uint32_t result = 0;
+
+    for (uint8_t i = 0; i < 4; i++) {
+        if (*offset >= data_len) {
+            return OPRT_SVC_BT_API_TRSMITR_ERROR;
+        }
+
+        uint8_t digit = data[(*offset)++];
+        result |= (uint32_t)(digit & 0x7f) << (i * 7);
+        if ((digit & 0x80) == 0) {
+            *value = result;
+            return OPRT_OK;
+        }
+    }
+
+    return OPRT_SVC_BT_API_TRSMITR_ERROR;
+}
+
+static int ble_frame_varint_encode(uint32_t value, uint8_t *data, uint16_t capacity, uint16_t *offset)
+{
+    do {
+        if (*offset >= capacity) {
+            return OPRT_INVALID_PARM;
+        }
+
+        uint8_t digit = value & 0x7f;
+        value >>= 7;
+        data[(*offset)++] = digit | (value != 0 ? 0x80 : 0);
+    } while (value != 0);
+
+    return OPRT_OK;
+}
 
 /***********************************************************
 *************************function define********************
@@ -47,13 +84,19 @@ ble_frame_trsmitr_t *ble_frame_trsmitr_create(void)
         return NULL;
     }
     memset(trsmitr, 0, sizeof(ble_frame_trsmitr_t));
-    trsmitr->subpkg = (uint8_t *)tal_malloc(ble_frame_packet_len_get());
+    trsmitr->subpkg_capacity = ble_frame_packet_len_get();
+    if (trsmitr->subpkg_capacity == 0 || trsmitr->subpkg_capacity > TUYA_BLE_AIR_FRAME_MAX) {
+        tal_free(trsmitr);
+        return NULL;
+    }
+
+    trsmitr->subpkg = (uint8_t *)tal_malloc(trsmitr->subpkg_capacity);
     if (trsmitr->subpkg == NULL) {
         PR_ERR("malloc err:%d", ble_frame_packet_len_get());
         tal_free(trsmitr);
         return NULL;
     }
-    memset(trsmitr->subpkg, 0, ble_frame_packet_len_get());
+    memset(trsmitr->subpkg, 0, trsmitr->subpkg_capacity);
 
     return trsmitr;
 }
@@ -68,8 +111,24 @@ ble_frame_trsmitr_t *ble_frame_trsmitr_create(void)
  */
 void ble_frame_trsmitr_delete(ble_frame_trsmitr_t *trsmitr)
 {
+    if (trsmitr == NULL) {
+        return;
+    }
+
     tal_free(trsmitr->subpkg);
     tal_free(trsmitr);
+}
+
+void ble_frame_trsmitr_reset(ble_frame_trsmitr_t *trsmitr)
+{
+    if (trsmitr == NULL) {
+        return;
+    }
+    uint8_t *subpkg   = trsmitr->subpkg;
+    uint32_t capacity = trsmitr->subpkg_capacity;
+    memset(trsmitr, 0, sizeof(*trsmitr));
+    trsmitr->subpkg          = subpkg;
+    trsmitr->subpkg_capacity = capacity;
 }
 
 /**
@@ -127,7 +186,9 @@ unsigned char *ble_frame_subpacket_get(ble_frame_trsmitr_t *trsmitr)
 
 static ble_frame_seq_t ble_frame_seq_get(void)
 {
-    return (s_ble_frame_seq >= BLE_FRAME_SEQ_LMT) ? 0 : s_ble_frame_seq++;
+    ble_frame_seq_t seq = s_ble_frame_seq;
+    s_ble_frame_seq     = (s_ble_frame_seq + 1) % BLE_FRAME_SEQ_LMT;
+    return seq;
 }
 
 /**
@@ -150,78 +211,64 @@ static ble_frame_seq_t ble_frame_seq_get(void)
 int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned char version, unsigned char *buf,
                                       unsigned int len)
 {
-    if (((void *)0) == trsmitr) {
+    if (trsmitr == NULL || trsmitr->subpkg == NULL || (buf == NULL && len != 0)) {
         return OPRT_INVALID_PARM;
     }
 
-    if (BLE_FRAME_PKG_INIT == trsmitr->pkg_desc) {
-        trsmitr->total = len;
-        trsmitr->version = version;
-        trsmitr->seq = ble_frame_seq_get();
-        trsmitr->subpkg_num = 0;
-        trsmitr->pkg_trsmitr_cnt = 0;
+    if (trsmitr->subpkg_capacity < BLE_FRAME_HEADER_MAX_LEN + 1U || trsmitr->subpkg_capacity > TUYA_BLE_AIR_FRAME_MAX) {
+        return OPRT_INVALID_PARM;
     }
-
-    if (trsmitr->subpkg_num >= 0x10000000 || len >= 0x10000000) {
+    if (len == 0 || len > TUYA_BLE_AIR_FRAME_MAX) {
         return OPRT_COM_ERROR;
     }
 
-    unsigned char sunpkg_offset = 0;
+    bool is_first = (BLE_FRAME_PKG_INIT == trsmitr->pkg_desc);
+    if (!is_first &&
+        (trsmitr->total != len || trsmitr->pkg_trsmitr_cnt > len || trsmitr->pkg_desc == BLE_FRAME_PKG_END)) {
+        return OPRT_INVALID_PARM;
+    }
 
-    // package code
-    // subpackage num encode
-    int i;
-    unsigned int tmp = 0;
-    tmp = trsmitr->subpkg_num;
-    for (i = 0; i < 4; i++) {
-        trsmitr->subpkg[sunpkg_offset] = tmp % 0x80;
-        if ((tmp / 0x80)) {
-            trsmitr->subpkg[sunpkg_offset] |= 0x80;
+    uint32_t subpkg_num    = is_first ? 0 : trsmitr->subpkg_num;
+    uint16_t subpkg_offset = 0;
+    int      rt = ble_frame_varint_encode(subpkg_num, trsmitr->subpkg, trsmitr->subpkg_capacity, &subpkg_offset);
+    if (rt != OPRT_OK) {
+        return rt;
+    }
+
+    if (is_first) {
+        rt = ble_frame_varint_encode(len, trsmitr->subpkg, trsmitr->subpkg_capacity, &subpkg_offset);
+        if (rt != OPRT_OK || subpkg_offset >= trsmitr->subpkg_capacity) {
+            return OPRT_INVALID_PARM;
         }
-        sunpkg_offset++;
-        tmp /= 0x80;
-        if (0 == tmp) {
-            break;
-        }
     }
 
-    // the first package include the frame total len
-    if (0 == trsmitr->subpkg_num) {
-        // frame len encode
-        tmp = len;
-        for (i = 0; i < 4; i++) {
-            trsmitr->subpkg[sunpkg_offset] = tmp % 0x80;
-            if ((tmp / 0x80)) {
-                trsmitr->subpkg[sunpkg_offset] |= 0x80;
-            }
-            sunpkg_offset++;
-            tmp /= 0x80;
-            if (0 == tmp) {
-                break;
-            }
-        }
-
-        // frame type and frame seq
-        trsmitr->subpkg[sunpkg_offset++] = (trsmitr->version << 0x04) | (trsmitr->seq & 0x0f);
+    uint32_t sent      = is_first ? 0 : trsmitr->pkg_trsmitr_cnt;
+    uint32_t remaining = len - sent;
+    if (remaining != 0 && subpkg_offset >= trsmitr->subpkg_capacity - (is_first ? 1 : 0)) {
+        return OPRT_INVALID_PARM;
     }
 
-    // frame data transfer
-    uint16_t send_data = (ble_frame_packet_len_get() - sunpkg_offset);
-    if ((len - trsmitr->pkg_trsmitr_cnt) < send_data) {
-        send_data = len - trsmitr->pkg_trsmitr_cnt;
+    ble_frame_seq_t seq = is_first ? ble_frame_seq_get() : trsmitr->seq;
+    if (is_first) {
+        trsmitr->subpkg[subpkg_offset++] = (version << 4) | (seq & 0x0f);
     }
 
-    PR_TRACE("pkg max len:%d, sunpkg_offset:%d, send_data:%d", ble_frame_packet_len_get(), sunpkg_offset, send_data);
-
-    memcpy(&(trsmitr->subpkg[sunpkg_offset]), buf + trsmitr->pkg_trsmitr_cnt, send_data);
-    trsmitr->subpkg_len = sunpkg_offset + send_data;
-
-    trsmitr->pkg_trsmitr_cnt += send_data;
-    if (0 == trsmitr->subpkg_num) {
-        trsmitr->pkg_desc = BLE_FRAME_PKG_FIRST;
-    } else {
-        trsmitr->pkg_desc = BLE_FRAME_PKG_MIDDLE;
+    uint32_t available = trsmitr->subpkg_capacity - subpkg_offset;
+    uint16_t send_data = remaining < available ? remaining : available;
+    PR_TRACE("pkg max len:%d, subpkg_offset:%d, send_data:%d", trsmitr->subpkg_capacity, subpkg_offset, send_data);
+    if (send_data != 0) {
+        memcpy(&trsmitr->subpkg[subpkg_offset], buf + sent, send_data);
     }
+
+    if (is_first) {
+        trsmitr->total      = len;
+        trsmitr->version    = version;
+        trsmitr->seq        = seq;
+        trsmitr->subpkg_num = 0;
+    }
+    trsmitr->subpkg_len      = subpkg_offset + send_data;
+    trsmitr->pkg_trsmitr_cnt = sent + send_data;
+    trsmitr->pkg_desc        = is_first ? BLE_FRAME_PKG_FIRST : BLE_FRAME_PKG_MIDDLE;
 
     if (trsmitr->pkg_trsmitr_cnt < trsmitr->total) {
         trsmitr->subpkg_num++;
@@ -257,94 +304,68 @@ int ble_frame_trsmitr_send_pkg_encode(ble_frame_trsmitr_t *trsmitr, unsigned cha
  */
 int ble_frame_trsmitr_recv_pkg_decode(ble_frame_trsmitr_t *trsmitr, unsigned char *raw_data, uint16_t raw_data_len)
 {
-    if (NULL == raw_data || NULL == trsmitr) { //|| (raw_data_len > ble_frame_packet_len_get())
+    if (raw_data == NULL || trsmitr == NULL || trsmitr->subpkg == NULL || raw_data_len == 0 ||
+        raw_data_len > trsmitr->subpkg_capacity || raw_data_len > TUYA_BLE_AIR_FRAME_MAX) {
         return OPRT_INVALID_PARM;
     }
 
-    if (BLE_FRAME_PKG_INIT == trsmitr->pkg_desc) {
-        trsmitr->total = 0;
-        trsmitr->version = 0;
-        trsmitr->seq = 0;
-        trsmitr->pkg_trsmitr_cnt = 0;
+    uint16_t               subpkg_offset = 0;
+    ble_frame_subpkg_num_t subpkg_num    = 0;
+    if (ble_frame_varint_decode(raw_data, raw_data_len, &subpkg_offset, &subpkg_num) != OPRT_OK) {
+        return OPRT_SVC_BT_API_TRSMITR_ERROR;
     }
 
-    unsigned char sunpkg_offset = 0;
-    // package code
-    // subpackage num decode
-    int i;
-    unsigned int multiplier = 1;
-    unsigned char digit;
-    ble_frame_subpkg_num_t subpkg_num = 0;
-    // Package number
-    for (i = 0; i < 4; i++) {
-        digit = raw_data[sunpkg_offset++];
-        subpkg_num += (digit & 0x7f) * multiplier;
-        multiplier *= 0x80;
-
-        if (0 == (digit & 0x80)) {
-            break;
-        }
-    }
-    // PR_DEBUG("subpkg_num:%d, trsmitr->subpkg_num:%d", subpkg_num,
-    // trsmitr->subpkg_num);
-    if (0 == subpkg_num) {
-        trsmitr->total = 0;
-        trsmitr->version = 0;
-        trsmitr->seq = 0;
-        trsmitr->pkg_trsmitr_cnt = 0;
-        trsmitr->pkg_desc = BLE_FRAME_PKG_FIRST;
-    } else {
-        trsmitr->pkg_desc = BLE_FRAME_PKG_MIDDLE;
-    }
-
-    if (trsmitr->subpkg_num >= 0x10000000) {
-        return OPRT_COM_ERROR;
-    }
-    // is receive the subpackage num valid?
-    if (trsmitr->pkg_desc != BLE_FRAME_PKG_FIRST) {
-        if (subpkg_num < trsmitr->subpkg_num) {
-            return OPRT_SVC_BT_API_TRSMITR_ERROR;
-        } else if (subpkg_num == trsmitr->subpkg_num) {
-            return OPRT_SVC_BT_API_TRSMITR_CONTINUE;
-        }
-
-        if (subpkg_num - trsmitr->subpkg_num > 1) {
+    bool              is_first = (subpkg_num == 0);
+    ble_frame_total_t total    = trsmitr->total;
+    uint32_t          received = trsmitr->pkg_trsmitr_cnt;
+    uint8_t           version  = trsmitr->version;
+    ble_frame_seq_t   seq      = trsmitr->seq;
+    if (is_first) {
+        if (ble_frame_varint_decode(raw_data, raw_data_len, &subpkg_offset, &total) != OPRT_OK || total == 0 ||
+            total > TUYA_BLE_AIR_FRAME_MAX || subpkg_offset >= raw_data_len) {
             return OPRT_SVC_BT_API_TRSMITR_ERROR;
         }
+
+        version  = (raw_data[subpkg_offset] & BLE_FRAME_VERSION_OFFSET) >> 4;
+        seq      = raw_data[subpkg_offset++] & BLE_FRAME_SEQ_OFFSET;
+        received = 0;
     }
-    trsmitr->subpkg_num = subpkg_num;
 
-    if (0 == trsmitr->subpkg_num) {
-        // frame len decode
-        multiplier = 1;
-        for (i = 0; i < 4; i++) {
-            digit = raw_data[sunpkg_offset++];
-            trsmitr->total += (digit & 0x7f) * multiplier;
-            multiplier *= 0x80;
+    uint16_t recv_data       = raw_data_len - subpkg_offset;
+    bool     exact_duplicate = trsmitr->pkg_desc != BLE_FRAME_PKG_INIT && subpkg_num == trsmitr->subpkg_num &&
+                           total == trsmitr->total && version == trsmitr->version && seq == trsmitr->seq &&
+                           recv_data == trsmitr->subpkg_len &&
+                           (recv_data == 0 || memcmp(trsmitr->subpkg, &raw_data[subpkg_offset], recv_data) == 0);
+    if (exact_duplicate) {
+        return OPRT_SVC_BT_API_TRSMITR_CONTINUE;
+    }
 
-            if (0 == (digit & 0x80)) {
-                break;
-            }
+    if (received > total || recv_data > total - received || recv_data > trsmitr->subpkg_capacity) {
+        return OPRT_SVC_BT_API_TRSMITR_ERROR;
+    }
+    if (recv_data == 0 && received < total) {
+        return OPRT_SVC_BT_API_TRSMITR_ERROR;
+    }
+
+    if (is_first) {
+        if (trsmitr->pkg_desc != BLE_FRAME_PKG_INIT && trsmitr->pkg_desc != BLE_FRAME_PKG_END) {
+            return OPRT_SVC_BT_API_TRSMITR_ERROR;
         }
-
-        if (trsmitr->total >= 0x10000000) {
-            return OPRT_COM_ERROR;
-        }
-
-        // frame type and frame seq decode
-        trsmitr->version = (raw_data[sunpkg_offset] & BLE_FRAME_VERSION_OFFSET) >> 4;
-        trsmitr->seq = raw_data[sunpkg_offset++] & BLE_FRAME_SEQ_OFFSET;
+    } else if ((trsmitr->pkg_desc != BLE_FRAME_PKG_FIRST && trsmitr->pkg_desc != BLE_FRAME_PKG_MIDDLE) ||
+               trsmitr->subpkg_num >= 0x0fffffff || subpkg_num != trsmitr->subpkg_num + 1) {
+        return OPRT_SVC_BT_API_TRSMITR_ERROR;
     }
 
-    uint16_t recv_data = raw_data_len - sunpkg_offset;
-    if ((trsmitr->total - trsmitr->pkg_trsmitr_cnt) < recv_data) {
-        recv_data = trsmitr->total - trsmitr->pkg_trsmitr_cnt;
+    if (recv_data != 0) {
+        memcpy(trsmitr->subpkg, &raw_data[subpkg_offset], recv_data);
     }
-
-    // decode data cp to transmitter subpackage buf
-    memcpy(trsmitr->subpkg, &raw_data[sunpkg_offset], recv_data);
-    trsmitr->subpkg_len = recv_data;
-    trsmitr->pkg_trsmitr_cnt += recv_data;
+    trsmitr->total           = total;
+    trsmitr->version         = version;
+    trsmitr->seq             = seq;
+    trsmitr->subpkg_num      = subpkg_num;
+    trsmitr->subpkg_len      = recv_data;
+    trsmitr->pkg_trsmitr_cnt = received + recv_data;
+    trsmitr->pkg_desc        = is_first ? BLE_FRAME_PKG_FIRST : BLE_FRAME_PKG_MIDDLE;
 
     if (trsmitr->pkg_trsmitr_cnt < trsmitr->total) {
         return OPRT_SVC_BT_API_TRSMITR_CONTINUE;

--- a/src/tuya_cloud_service/ble/ble_trsmitr.h
+++ b/src/tuya_cloud_service/ble/ble_trsmitr.h
@@ -8,7 +8,7 @@
  * for module-wide use. The module facilitates the encoding and transmission of
  * BLE frames between devices.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -35,6 +35,7 @@ extern "C" {
 #define BLE_FRAME_VERSION_OFFSET (0x0f << 4)
 #define BLE_FRAME_SEQ_OFFSET     (0x0f << 0)
 #define BLE_FRAME_SEQ_LMT        16
+#define BLE_FRAME_HEADER_MAX_LEN 9U
 
 // frame total len
 typedef uint32_t ble_frame_total_t;
@@ -54,15 +55,16 @@ typedef uint8_t ble_frame_pkg_desc_t;
 
 // frame transmitter process
 typedef struct {
-    ble_frame_total_t total;           // 4 bytes, total data length, excluding header
-    uint8_t version;                   // 1 byte, protocol major version number
-    ble_frame_seq_t seq;               // 1 byte,
-    ble_frame_pkg_desc_t pkg_desc;     // 1 byte, current subpackage frame type
-                                       // (init/first/middle/end)
-    ble_frame_subpkg_num_t subpkg_num; // 4 bytes, current subpackage number
-    uint32_t pkg_trsmitr_cnt;          // package process count, number of bytes sent
-    ble_frame_subpkg_len_t subpkg_len; // 1 byte, data length in the current subpackage
-    uint8_t *subpkg;
+    ble_frame_total_t    total;             // 4 bytes, total data length, excluding header
+    uint8_t              version;           // 1 byte, protocol major version number
+    ble_frame_seq_t      seq;               // 1 byte,
+    ble_frame_pkg_desc_t pkg_desc;          // 1 byte, current subpackage frame type
+                                            // (init/first/middle/end)
+    ble_frame_subpkg_num_t subpkg_num;      // 4 bytes, current subpackage number
+    uint32_t               pkg_trsmitr_cnt; // package process count, number of bytes sent
+    ble_frame_subpkg_len_t subpkg_len;      // 1 byte, data length in the current subpackage
+    uint32_t               subpkg_capacity; // allocated size of subpkg
+    uint8_t               *subpkg;
 } ble_frame_trsmitr_t;
 
 /***********************************************************
@@ -91,6 +93,8 @@ ble_frame_trsmitr_t *ble_frame_trsmitr_create(void);
  */
 __BLE_TRSMITR_EXT
 void ble_frame_trsmitr_delete(ble_frame_trsmitr_t *frm_trsmitr);
+__BLE_TRSMITR_EXT
+void ble_frame_trsmitr_reset(ble_frame_trsmitr_t *frm_trsmitr);
 
 /**
  * @brief Get the length of the subpacket in a BLE frame transmitter.

--- a/src/tuya_cloud_service/schema/dp_schema.c
+++ b/src/tuya_cloud_service/schema/dp_schema.c
@@ -8,7 +8,7 @@
  * a larger framework aimed at device management and communication in IoT
  * applications.
  *
- * @copyright Copyright (c) 2021-2024 Tuya Inc. All Rights Reserved.
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
  *
  */
 
@@ -28,9 +28,9 @@
 
 typedef struct {
     // DELAYED_WORK_HANDLE tmm_dp_sync;
-    uint16_t serial_no;
+    uint16_t     serial_no;
     MUTEX_HANDLE mutex;
-    uint8_t schema_num;
+    uint8_t      schema_num;
     dp_schema_t *schema_list[DP_SCHEMA_NUM_MAX];
 } dp_schema_mgr_t;
 
@@ -96,8 +96,8 @@ int dp_rept_json_append(dp_schema_t *schema, char *data, char *time, char *type,
     memset(tmp, 0, len);
 
     int offset = 0;
-    int ret = 0;
-    ret = snprintf(tmp + offset, len - offset, "{\"dps\":%s,\"devId\":\"%s\"", data, schema->devid);
+    int ret    = 0;
+    ret        = snprintf(tmp + offset, len - offset, "{\"dps\":%s,\"devId\":\"%s\"", data, schema->devid);
     if (ret < 0 || ret >= len - offset) {
         goto __err_exit;
     }
@@ -124,7 +124,7 @@ int dp_rept_json_append(dp_schema_t *schema, char *data, char *time, char *type,
         offset += ret;
     }
     tmp[offset] = '}';
-    *pp_out = tmp;
+    *pp_out     = tmp;
 
     return OPRT_OK;
 
@@ -143,8 +143,12 @@ __err_exit:
  */
 dp_node_t *dp_node_find(dp_schema_t *schema, int id)
 {
-    int i;
+    int        i;
     dp_node_t *dpnode = NULL;
+
+    if (schema == NULL || schema->num == 0) {
+        return NULL;
+    }
 
     for (i = 0; i < schema->num; i++) {
         if (schema->node[i].desc.id == id) {
@@ -193,7 +197,7 @@ dp_schema_t *dp_schema_find(const char *devid)
  */
 dp_node_t *dp_node_find_by_devid(char *devid, int id)
 {
-    int i;
+    int        i;
     dp_node_t *dpnode = NULL;
 
     dp_schema_t *schema = dp_schema_find(devid);
@@ -227,7 +231,7 @@ static __attribute__((unused)) OPERATE_RET dp_obj_equal_resp(dp_schema_t *schema
     int i;
     tal_mutex_lock(schema->mutex);
     for (i = 0; i < num; i++) {
-        int id = dpid[i];
+        int        id     = dpid[i];
         dp_node_t *dpnode = dp_node_find(schema, id);
         if (dpnode == NULL) {
             PR_ERR("dp id Invalid %d", id);
@@ -274,7 +278,7 @@ static __attribute__((unused)) OPERATE_RET dp_obj_equal_resp(dp_schema_t *schema
     tal_mutex_unlock(schema->mutex);
 
     char *tmp = NULL;
-    tmp = cJSON_PrintUnformatted(qr_data);
+    tmp       = cJSON_PrintUnformatted(qr_data);
     cJSON_Delete(qr_data);
     if (NULL == tmp) {
         PR_ERR("json err");
@@ -332,13 +336,13 @@ static __attribute__((unused)) OPERATE_RET dp_obj_equal_resp(dp_schema_t *schema
  */
 int dp_data_recv_parse(dp_recv_msg_t *msg, dp_recv_cb_t dp_recv_cb)
 {
-    OPERATE_RET op_ret = OPRT_OK;
-    uint16_t dpscnt = 0;
-    dp_obj_recv_t *dpobj = NULL;
-    dp_node_t *dpnode = NULL;
-    cJSON *item = NULL;
-    dp_schema_t *schema = dp_schema_find(msg->devid);
-    cJSON *dps_js = cJSON_GetObjectItem(msg->data_js, "dps");
+    OPERATE_RET    op_ret = OPRT_OK;
+    uint16_t       dpscnt = 0;
+    dp_obj_recv_t *dpobj  = NULL;
+    dp_node_t     *dpnode = NULL;
+    cJSON         *item   = NULL;
+    dp_schema_t   *schema = dp_schema_find(msg->devid);
+    cJSON         *dps_js = cJSON_GetObjectItem(msg->data_js, "dps");
 
     if (NULL == schema || NULL == dps_js) {
         PR_ERR("dev null or no dps");
@@ -372,7 +376,7 @@ int dp_data_recv_parse(dp_recv_msg_t *msg, dp_recv_cb_t dp_recv_cb)
         memset(dpobj, 0, (sizeof(dp_obj_recv_t) + (dpscnt * sizeof(dp_obj_t))));
         dpobj->cmd_tp = msg->cmd;
         dpobj->dtt_tp = (dp_trans_type_t)msg->dt_tp;
-        dpobj->devid = msg->devid;
+        dpobj->devid  = msg->devid;
         dpobj->dpscnt = dpscnt;
     }
     /*
@@ -389,17 +393,17 @@ int dp_data_recv_parse(dp_recv_msg_t *msg, dp_recv_cb_t dp_recv_cb)
         }
         if (T_RAW == dpnode->desc.type && cJSON_String == item->type) { // raw dp process
             // dp_raw_t
-            int data_len = sizeof(dp_raw_recv_t) + strlen(item->valuestring);
-            dp_raw_recv_t *dpraw = tal_malloc(data_len);
+            int            data_len = sizeof(dp_raw_recv_t) + strlen(item->valuestring);
+            dp_raw_recv_t *dpraw    = tal_malloc(data_len);
             if (NULL == dpraw) {
                 tal_mutex_unlock(schema->mutex);
                 goto __err_exit;
             }
             memset(dpraw, 0, data_len);
 
-            dpraw->devid = msg->devid;
+            dpraw->devid  = msg->devid;
             dpraw->cmd_tp = msg->cmd;
-            dpraw->dp.id = dpnode->desc.id;
+            dpraw->dp.id  = dpnode->desc.id;
             dpraw->dtt_tp = msg->dt_tp;
             dpraw->dp.len = tuya_base64_decode(item->valuestring, dpraw->dp.data);
 
@@ -472,8 +476,8 @@ int dp_data_recv_parse(dp_recv_msg_t *msg, dp_recv_cb_t dp_recv_cb)
             continue;
         }
         } /* end of switch */
-        dpobj->dps[i].id = dpnode->desc.id;
-        dpobj->dps[i].type = dpnode->desc.prop_tp;
+        dpobj->dps[i].id         = dpnode->desc.id;
+        dpobj->dps[i].type       = dpnode->desc.prop_tp;
         dpobj->dps[i].time_stamp = tal_time_get_posix();
         i++;
     } /* end of for */
@@ -594,7 +598,7 @@ static bool dp_rept_update(dp_rept_type_t rept_type, dp_obj_t *dp, dp_node_t *dp
                         dpnode->prop.prop_str.value = NULL;
                     }
                     dpnode->prop.prop_str.cur_len = strlen(dp->value.dp_str);
-                    dpnode->prop.prop_str.value = tal_malloc(dpnode->prop.prop_str.cur_len + 1);
+                    dpnode->prop.prop_str.value   = tal_malloc(dpnode->prop.prop_str.cur_len + 1);
                     if (dpnode->prop.prop_str.value) {
                         memcpy(dpnode->prop.prop_str.value, dp->value.dp_str, dpnode->prop.prop_str.cur_len);
                         dpnode->prop.prop_str.value[dpnode->prop.prop_str.cur_len] = '\0';
@@ -654,7 +658,7 @@ static bool dp_rept_update(dp_rept_type_t rept_type, dp_obj_t *dp, dp_node_t *dp
         break;
     }
     case T_RAW: {
-        is_need_update = TRUE;
+        is_need_update  = TRUE;
         dpnode->pv_stat = PV_STAT_LOCAL;
         break;
     }
@@ -778,7 +782,7 @@ int dp_rept_valid_check(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t
 
     tal_mutex_lock(schema->mutex);
     for (i = 0; i < dpin->dpscnt; i++) {
-        dp_obj_t *dp = &(dpin->dps[i]);
+        dp_obj_t  *dp     = &(dpin->dps[i]);
         dp_node_t *dpnode = dp_node_find(schema, dp->id);
         if (NULL == dpnode) {
             PR_ERR("dpnode[%d]: dpid %d not find", i, dp->id);
@@ -867,13 +871,13 @@ int dp_rept_valid_check(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t
  */
 int dp_rept_json_output(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t *dpvalid, dp_rept_out_t *dpout)
 {
-    uint16_t i, j;
-    size_t offset = 0;
-    size_t time_offset = 0;
-    OPERATE_RET op_ret = OPRT_OK;
-    char *dpstr = NULL;
-    char *dptimestr = NULL;
-    bool is_need_time = false;
+    uint16_t    i, j;
+    size_t      offset       = 0;
+    size_t      time_offset  = 0;
+    OPERATE_RET op_ret       = OPRT_OK;
+    char       *dpstr        = NULL;
+    char       *dptimestr    = NULL;
+    bool        is_need_time = false;
 
     dpstr = (char *)tal_malloc(dpvalid->len);
     if (NULL == dpstr) {
@@ -955,8 +959,7 @@ int dp_rept_json_output(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t
         }
 
         case PROP_BITMAP: {
-            if (!dp_snprintf_append(dpstr, dpvalid->len, &offset, "\"%d\":%" PRIu32 ",", dp->id,
-                                    dp->value.dp_bitmap)) {
+            if (!dp_snprintf_append(dpstr, dpvalid->len, &offset, "\"%d\":%" PRIu32 ",", dp->id, dp->value.dp_bitmap)) {
                 op_ret = OPRT_BUFFER_NOT_ENOUGH;
                 goto __err_exit;
             }
@@ -965,7 +968,7 @@ int dp_rept_json_output(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t
 
         case PROP_STR: {
             cJSON *temp_str = cJSON_CreateString(dp->value.dp_str);
-            char *tmp_data = cJSON_PrintUnformatted(temp_str);
+            char  *tmp_data = cJSON_PrintUnformatted(temp_str);
             if (tmp_data) {
                 if (!dp_snprintf_append(dpstr, dpvalid->len, &offset, "\"%d\":%s,", dp->id, tmp_data)) {
                     cJSON_free(tmp_data);
@@ -1002,7 +1005,7 @@ int dp_rept_json_output(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t
     }
 
     dpstr[offset - 1] = '}';
-    dpstr[offset] = 0;
+    dpstr[offset]     = 0;
 
     dpout->dpsjson = dpstr;
 
@@ -1014,7 +1017,7 @@ int dp_rept_json_output(dp_schema_t *schema, dp_rept_in_t *dpin, dp_rept_valid_t
             goto __err_exit;
         }
         dptimestr[time_offset - 1] = '}';
-        dptimestr[time_offset] = 0;
+        dptimestr[time_offset]     = 0;
         PR_DEBUG("dptimestr:%s", dptimestr);
         dpout->timejson = dptimestr;
     }
@@ -1139,10 +1142,10 @@ static int dp_obj_json_create(cJSON *root, dp_node_t *dpnode)
  */
 int dp_obj_dump_stat_local_json(char *devid, dp_rept_valid_t **outdpvalid, char **outjson, int flags)
 {
-    int i;
-    size_t length = 0;
-    dp_schema_t *schema = dp_schema_find(devid);
-    uint8_t dp_stat_local_num = 0;
+    int          i;
+    size_t       length            = 0;
+    dp_schema_t *schema            = dp_schema_find(devid);
+    uint8_t      dp_stat_local_num = 0;
 
     for (i = 0; i < schema->num; i++) {
         dp_node_t *dpnode = &(schema->node[i]);
@@ -1206,10 +1209,10 @@ int dp_obj_dump_stat_local_json(char *devid, dp_rept_valid_t **outdpvalid, char 
     if (flags & DP_APPEND_HEADER_FLAG) {
         dp_rept_json_append(schema, jsonstr, NULL, NULL, 0, &out);
         cJSON_free(jsonstr);
-    }else {
+    } else {
         size_t jsonstr_len = strlen(jsonstr);
-        out = tal_malloc(jsonstr_len + 1);
-        if(out) {
+        out                = tal_malloc(jsonstr_len + 1);
+        if (out) {
             memset(out, 0, jsonstr_len + 1);
             memcpy(out, jsonstr, jsonstr_len);
         }
@@ -1252,7 +1255,7 @@ char *dp_obj_dump_all_json(char *devid, int flags)
         return NULL;
     }
 
-    size_t length = 0;
+    size_t       length = 0;
     dp_schema_t *schema = dp_schema_find(devid);
     if (NULL == schema) {
         cJSON_Delete(cjson);
@@ -1294,7 +1297,7 @@ char *dp_obj_dump_all_json(char *devid, int flags)
         PR_ERR("malloc err");
         cJSON_free(tmp);
         return NULL;
-    }else {
+    } else {
         memset(out_str, 0, strlen(tmp) + 1);
         strcpy(out_str, tmp);
         cJSON_free(tmp);
@@ -1350,13 +1353,13 @@ static int dp_node_pos_decode(char *schema_json, dp_node_pos_t pos[], int pos_nu
 static OPERATE_RET dp_node_parse(char *schema_json, dp_node_pos_t *nodepos, uint16_t nodenum, dp_node_t *dpnode,
                                  SCHEMA_OTHER_ATTR_S *other_attr)
 {
-    OPERATE_RET op_ret = OPRT_OK;
-    dp_desc_t *dp_desc;
+    OPERATE_RET      op_ret = OPRT_OK;
+    dp_desc_t       *dp_desc;
     dp_prop_vaule_t *prop;
 
     cJSON *cjson = NULL;
-    cJSON *item = NULL;
-    char *pBuf = NULL;
+    cJSON *item  = NULL;
+    char  *pBuf  = NULL;
 
     pBuf = (char *)tal_malloc(MAX_ITEM_LEN);
     if (NULL == pBuf) {
@@ -1369,7 +1372,7 @@ static OPERATE_RET dp_node_parse(char *schema_json, dp_node_pos_t *nodepos, uint
 
     for (i = 0; i < nodenum; i++) {
         dp_desc = &(dpnode[i].desc);
-        prop = &(dpnode[i].prop);
+        prop    = &(dpnode[i].prop);
 
         memset(pBuf, 0, MAX_ITEM_LEN);
         memcpy(pBuf, schema_json + nodepos[i].start, nodepos[i].end - nodepos[i].start + 1);
@@ -1485,8 +1488,8 @@ static OPERATE_RET dp_node_parse(char *schema_json, dp_node_pos_t *nodepos, uint
             dp_desc->prop_tp = PROP_BOOL;
         } else if (!strcmp(child->valuestring, "value")) {
             dp_desc->prop_tp = PROP_VALUE;
-            char *str[] = {"max", "min", "scale"};
-            int i;
+            char *str[]      = {"max", "min", "scale"};
+            int   i;
             for (i = 0; i < CNTSOF(str); i++) {
                 child = cJSON_GetObjectItem(item, str[i]);
                 if (NULL == child && (i != CNTSOF(str) - 1)) {
@@ -1511,16 +1514,16 @@ static OPERATE_RET dp_node_parse(char *schema_json, dp_node_pos_t *nodepos, uint
             }
         } else if (!strcmp(child->valuestring, "string")) {
             dp_desc->prop_tp = PROP_STR;
-            child = cJSON_GetObjectItem(item, "maxlen");
+            child            = cJSON_GetObjectItem(item, "maxlen");
             if (NULL == child) {
                 PR_ERR("get maxlen null");
                 op_ret = OPRT_CJSON_GET_ERR;
                 goto __exit;
             }
             prop->prop_str.max_len = child->valueint;
-            prop->prop_str.value = NULL;
+            prop->prop_str.value   = NULL;
             prop->prop_str.cur_len = 0;
-            op_ret = tal_mutex_create_init(&prop->prop_str.dp_str_mutex);
+            op_ret                 = tal_mutex_create_init(&prop->prop_str.dp_str_mutex);
             if (OPRT_OK != op_ret) {
                 PR_ERR("mutex init fail:%d", op_ret);
                 op_ret = OPRT_CR_MUTEX_ERR;
@@ -1528,7 +1531,7 @@ static OPERATE_RET dp_node_parse(char *schema_json, dp_node_pos_t *nodepos, uint
             }
         } else if (!strcmp(child->valuestring, "enum")) {
             dp_desc->prop_tp = PROP_ENUM;
-            child = cJSON_GetObjectItem(item, "range");
+            child            = cJSON_GetObjectItem(item, "range");
             if (NULL == child) {
                 PR_ERR("get range null");
                 op_ret = OPRT_CJSON_GET_ERR;
@@ -1564,7 +1567,7 @@ static OPERATE_RET dp_node_parse(char *schema_json, dp_node_pos_t *nodepos, uint
             }
         } else if (!strcmp(child->valuestring, "bitmap")) {
             dp_desc->prop_tp = PROP_BITMAP;
-            child = cJSON_GetObjectItem(item, "maxlen");
+            child            = cJSON_GetObjectItem(item, "maxlen");
             if (NULL == child) {
                 PR_ERR("get maxlen null");
                 op_ret = OPRT_CJSON_GET_ERR;
@@ -1613,9 +1616,9 @@ __exit:
  */
 int dp_schema_create(char *devid, char *schema_json, dp_schema_t **dp_schema_out)
 {
-    OPERATE_RET op_ret = OPRT_OK;
+    OPERATE_RET    op_ret  = OPRT_OK;
     dp_node_pos_t *nodepos = NULL;
-    int nodenum;
+    int            nodenum;
 
     nodepos = tal_malloc(sizeof(dp_node_pos_t) * 255);
     if (NULL == nodepos) {
@@ -1659,7 +1662,7 @@ int dp_schema_create(char *devid, char *schema_json, dp_schema_t **dp_schema_out
         PR_ERR("dp_node_parse fail:%d", op_ret);
         goto __exit;
     }
-    dp_schema->actv.preprocess = other_attr.preprocess;
+    dp_schema->actv.preprocess   = other_attr.preprocess;
     dp_schema->actv.attach_dp_if = TRUE;
     strncpy(dp_schema->devid, devid, DEV_ID_LEN);
     if (dp_schema_out) {


### PR DESCRIPTION
## Summary
- harden BLE transport and transparent-channel framing against malformed lengths, truncated varints, duplicate/out-of-order fragments, and buffer overflows
- enforce receive-side authorization for bound/unpaired devices and destructive BLE operations
- validate DP payloads, schema/enum values, netcfg input ownership, device-info capacity, and negotiated packet sizes
- reject pre-activation DP requests and send DP success ACK only after application parsing succeeds

## Verification
- Host ASan/UBSan security suite: 5/5 tests passed locally (tests intentionally kept out of this PR per request)
- ESP32-S3 BLE-enabled example: full build succeeded
- Existing provisioning/network configuration flow manually verified successfully
- No device flashing or radio PoC traffic was executed

The local regression tests remain untracked and are intentionally not included in this PR.
